### PR TITLE
NIAD-1271: Release 0.0.4, update release information, change port of …

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2021-03-30
+
+### Known Issues and Limitations
+
+- Same as for 0.0.3
+
+### Added
+
+NIAD-1126: Remove default value for ssp domain from yml
+NIAD-1182: Global Logging
+
 ## [0.0.3] - 2021-03-29
 
 ### Known Issues and Limitations

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
           context: ../
           dockerfile: docker/service/Dockerfile
       ports: 
-        - "8080:8090"
+        - "8090:8090"
       environment: 
         - GPC_CONSUMER_SERVER_PORT
         - GPC_CONSUMER_ROOT_LOGGING_LEVEL

--- a/docker/vars.local.sh
+++ b/docker/vars.local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export GPC_CONSUMER_SERVER_PORT="8080"
+export GPC_CONSUMER_SERVER_PORT="8090"
 export GPC_CONSUMER_GPC_GET_URL="http://localhost:8210"
-export GPC_CONSUMER_URL="http://localhost:8080"
+export GPC_CONSUMER_URL="http://localhost:8090"

--- a/docker/vars.opentest.sh
+++ b/docker/vars.opentest.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-export GPC_CONSUMER_SERVER_PORT="8080"
+export GPC_CONSUMER_SERVER_PORT="8090"
 export GPC_CONSUMER_GPC_GET_URL="https://messagingportal.opentest.hscic.gov.uk:19192"
-export GPC_CONSUMER_URL="http://localhost:8080"
+export GPC_CONSUMER_URL="http://localhost:8090"
 
 export GPC_CONSUMER_SPINE_CLIENT_CERT=""
 export GPC_CONSUMER_SPINE_CLIENT_KEY=""

--- a/docker/vars.public.sh
+++ b/docker/vars.public.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-export GPC_CONSUMER_SERVER_PORT="8080"
+export GPC_CONSUMER_SERVER_PORT="8090"
 export GPC_CONSUMER_GPC_GET_URL="https://orange.testlab.nhs.uk"
-export GPC_CONSUMER_URL="http://localhost:8080"
-
+export GPC_CONSUMER_URL="http://localhost:8090"

--- a/release/DOCKERHUB.md
+++ b/release/DOCKERHUB.md
@@ -23,7 +23,7 @@ you are testing to ensure compatibility with configurations and scripts.
 
 ```bash
 git pull
-git checkout 0.0.3
+git checkout 0.0.4
 ```
 
 ## Find the docker directory
@@ -45,7 +45,7 @@ cp vars.local.sh vars.sh
 ```
 
 Make any required changes to the `vars.sh` file. If using `vars.local.sh` you do not need to modify anything. Refer
-to the [README](https://github.com/nhsconnect/integration-adaptor-gpc-consumer/blob/0.0.3/README.md) for possible configuration
+to the [README](https://github.com/nhsconnect/integration-adaptor-gpc-consumer/blob/0.0.4/README.md) for possible configuration
 options.
 
 ## Find the release directory

--- a/release/tests/healthcheck.sh
+++ b/release/tests/healthcheck.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-curl -i --location --request GET 'http://localhost:8080/healthcheck'
+curl -i --location --request GET 'http://localhost:8090/healthcheck'

--- a/release/version.sh
+++ b/release/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-export RELEASE_VERSION=0.0.3
+export RELEASE_VERSION=0.0.4


### PR DESCRIPTION
…gpc consumer in docker configuration and healthcheck in relation to work with gp2gp which was on the same port before