### PR TITLE
Release an ARM version of the adaptor

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -4,17 +4,11 @@ set -e
 
 source ./version.sh
 
-cd ../docker
-docker-compose build gpc-consumer
+git fetch
+git checkout $RELEASE_VERSION
 
-docker tag local/gpc-consumer:latest nhsdev/nia-gpc-consumer-adaptor:${RELEASE_VERSION}
+cd ../
 
-docker scan --severity high --file ../docker/service/Dockerfile --exclude-base nhsdev/nia-gpc-consumer-adaptor:${RELEASE_VERSION}
+docker buildx build -f docker/service/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-gpc-consumer-adaptor:${RELEASE_VERSION} --push
 
-if [ "$1" == "-y" ];
-then
-  echo "Tagging and pushing Docker image and git tag"
-  docker push nhsdev/nia-gpc-consumer-adaptor:${RELEASE_VERSION}
-  git tag -a ${RELEASE_VERSION} -m "Release ${RELEASE_VERSION}"
-  git push origin ${RELEASE_VERSION}
-fi
+docker scout cves --only-severity critical,high --ignore-base nhsdev/nia-gpc-consumer-adaptor:${RELEASE_VERSION}

--- a/release/version.sh
+++ b/release/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-export RELEASE_VERSION=0.3.3
+export RELEASE_VERSION=0.3.4


### PR DESCRIPTION
This will make running the adaptor on an M1 Mac easier/faster.

To switch to buildx, the "confirmation" part of the release script has been removed as buildx has no "build" without push option.

Also, switch from docker scan to scout, its replacement.