### PR TITLE
NIAD-2997: Fetch ASID from SDS to populate Ssp-From header

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Fix GpConnectException (ASID_CHECK_FAILED_MESSAGESENDER) being thrown, 
+  a correct ASID value is fetched based on interactionId and ODS code, GPC_SUPPLIER_ODS_CODE should be set as env variable
+
 ## [0.3.4] - 2023-12-20
 - REST buffer limits have been increased to 150 Mb
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Fix GpConnectException (ASID_CHECK_FAILED_MESSAGESENDER) being thrown, 
-  a correct ASID value is fetched based on interactionId and ODS code, GPC_SUPPLIER_ODS_CODE should be set as env variable
+**Breaking Change**: New environment variable `GPC_SUPPLIER_ODS_CODE` is required to be set.
+
+### Fixed
+
+- Fix `GpConnectException` (ASID_CHECK_FAILED_MESSAGESENDER) from being thrown.
+  Previously the adaptor wasn't respecting the consumer rules of GP Connect,
+  and the Spine Secure Proxy would throw an error.
+  Now, a correct `Ssp-From` ASID value is fetched from SDS based on `interactionId`,
+  `ODS code`, and `GPC_SUPPLIER_ODS_CODE`.
 
 ## [0.3.4] - 2023-12-20
 - REST buffer limits have been increased to 150 Mb

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ to use the adaptor in the integration and production environments.
 | ------------------------|---------|-------------
 | GPC_CONSUMER_SDS_URL    |         | URL of the SDS FHIR API
 | GPC_CONSUMER_SDS_APIKEY |         | Secret key used to authenticate with the API
+| GPC_SUPPLIER_ODS_CODE   |         | Supplier ODS code [see GP Connect Docs](https://developer.nhs.uk/apis/gpconnect-1-6-0/integration_spine_directory_service.html#looking-up-a-consumers-own-asid)
 
 ### API Configuration Options
 

--- a/gpcc-mocks/src/main/java/uk/nhs/adaptors/gpccmocks/gpc/GpcController.java
+++ b/gpcc-mocks/src/main/java/uk/nhs/adaptors/gpccmocks/gpc/GpcController.java
@@ -39,6 +39,7 @@ import uk.nhs.adaptors.gpccmocks.common.TemplateUtils;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @RequestMapping("/{odsCode}/STU3/1/gpconnect")
 public class GpcController {
+
     @PostMapping(value = "/structured/fhir/Patient/$gpc.getstructuredrecord")
     @ResponseStatus(value = ACCEPTED)
     public ResponseEntity<String> accessStructuredRecord(

--- a/gpcc-mocks/src/main/java/uk/nhs/adaptors/gpccmocks/sds/SdsController.java
+++ b/gpcc-mocks/src/main/java/uk/nhs/adaptors/gpccmocks/sds/SdsController.java
@@ -25,6 +25,7 @@ import uk.nhs.adaptors.gpccmocks.common.TemplateUtils;
 @Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class SdsController {
+
     @GetMapping(value = "/spine-directory/Endpoint")
     public ResponseEntity<String> getEndpoint(
         HttpServletRequest request,

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/CloudGatewayRouteBaseTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/CloudGatewayRouteBaseTest.java
@@ -17,6 +17,7 @@ import uk.nhs.adaptors.gpc.consumer.testcontainers.GpccMockExtension;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(GpccMockExtension.class)
 public class CloudGatewayRouteBaseTest {
+
     protected static final String SSP_FROM_HEADER = "Ssp-From";
     protected static final String SSP_TO_HEADER = "Ssp-To";
     protected static final String SSP_INTERACTION_ID_HEADER = "Ssp-InteractionID";

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClientComponentTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClientComponentTest.java
@@ -1,5 +1,6 @@
 package uk.nhs.adaptors.gpc.consumer.sds;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -10,6 +11,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+import static uk.nhs.adaptors.gpc.consumer.gpc.InteractionIds.MIGRATE_STRUCTURED_ID;
 
 import java.util.List;
 import java.util.UUID;
@@ -47,7 +50,9 @@ import uk.nhs.adaptors.gpc.consumer.testcontainers.WiremockExtension;
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class SdsClientComponentTest {
+
     private static final String FROM_ODS_CODE = "ABC123";
+    private static final String SUPPLIER_ODS_CODE = "XYZ222";
     private static final String LOG_PREFIX = "Test log prefix";
     private static final String SSP_TRACE_ID = "Ssp-TraceID";
     private static final String X_CORRELATION_ID = String.valueOf(UUID.randomUUID());
@@ -55,16 +60,20 @@ public class SdsClientComponentTest {
     private static final String ASID = "928942012545";
     private static final String NHS_MHS_ID = "4ec1563fbe8e49bb8c3c";
 
-    private static final String GET_STRUCTURED_INTERACTION =
-        "urn:nhs:names:services:gpconnect:fhir:operation:gpc.getstructuredrecord-1";
-    private static final String PATIENT_SEARCH_ACCESS_DOCUMENT_INTERACTION =
-        "urn:nhs:names:services:gpconnect:documents:fhir:rest:search:patient-1";
-    private static final String SEARCH_FOR_DOCUMENT_INTERACTION =
-        "urn:nhs:names:services:gpconnect:documents:fhir:rest:search:documentreference-1";
-    private static final String RETRIEVE_DOCUMENT_INTERACTION =
-        "urn:nhs:names:services:gpconnect:documents:fhir:rest:read:binary-1";
-    private static final String MIGRATE_DOCUMENT_INTERACTION =
-        "urn:nhs:names:services:gpconnect:documents:fhir:rest:migrate:binary-1";
+    private static final String GET_STRUCTURED_INTERACTION
+                = "urn:nhs:names:services:gpconnect:fhir:operation:gpc.getstructuredrecord-1";
+    private static final String PATIENT_SEARCH_ACCESS_DOCUMENT_INTERACTION
+                = "urn:nhs:names:services:gpconnect:documents:fhir:rest:search:patient-1";
+    private static final String SEARCH_FOR_DOCUMENT_INTERACTION
+                = "urn:nhs:names:services:gpconnect:documents:fhir:rest:search:documentreference-1";
+    private static final String RETRIEVE_DOCUMENT_INTERACTION
+                = "urn:nhs:names:services:gpconnect:documents:fhir:rest:read:binary-1";
+    private static final String MIGRATE_DOCUMENT_INTERACTION
+                = "urn:nhs:names:services:gpconnect:documents:fhir:rest:migrate:binary-1";
+    private static final String MIGRATE_STRUCTURED_INTERACTION
+                = "urn:nhs:names:services:gpconnect:fhir:operation:gpc.migratestructuredrecord-1";
+    public static final String ENDPOINT = "/Endpoint";
+    public static final String DEVICE = "/Device";
 
     @Autowired
     private WireMockServer wireMockServer;
@@ -124,7 +133,10 @@ public class SdsClientComponentTest {
     }
 
     private void stubSdsOperation(String interaction, String path, String response) {
-        stubFor(get(urlPathEqualTo(path))
+        stubFor(get(urlEqualTo(path
+                              + "?organization=https://fhir.nhs.uk/Id/ods-organization-code%7C" + FROM_ODS_CODE
+                              + "&identifier=https://fhir.nhs.uk/Id/nhsServiceInteractionId%7C" + interaction))
+
             .withQueryParam("organization", equalTo("https://fhir.nhs.uk/Id/ods-organization-code|" + FROM_ODS_CODE))
             .withQueryParam("identifier", equalTo("https://fhir.nhs.uk/Id/nhsServiceInteractionId|" + interaction))
             .withHeader("apikey", matching(".*"))
@@ -132,6 +144,23 @@ public class SdsClientComponentTest {
             .willReturn(aResponse()
                 .withHeader("Content-Type", "application/fhir+json")
                 .withBody(response)));
+    }
+
+    private void stubSdsAsidOperation(String interaction, String path, String response) {
+        stubFor(get(urlEqualTo(path
+                                   + "?organization=https://fhir.nhs.uk/Id/ods-organization-code%7CABC123"
+                                   + "&identifier=" + "https://fhir.nhs.uk/Id/nhsServiceInteractionId%7C" + interaction
+                                   + "&manufacturing-organization=" + "https://fhir.nhs.uk/Id/ods-organization-code%7C" + SUPPLIER_ODS_CODE))
+
+                    .withQueryParam("organization", equalTo("https://fhir.nhs.uk/Id/ods-organization-code|" + FROM_ODS_CODE))
+                    .withQueryParam("identifier", equalTo("https://fhir.nhs.uk/Id/nhsServiceInteractionId|" + interaction))
+                    .withQueryParam("manufacturing-organization",
+                                                    equalTo("https://fhir.nhs.uk/Id/ods-organization-code|" + SUPPLIER_ODS_CODE))
+                    .withHeader("apikey", matching(".*"))
+                    .withHeader("X-Correlation-Id", matching("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"))
+                    .willReturn(aResponse()
+                                    .withHeader("Content-Type", "application/fhir+json")
+                                    .withBody(response)));
     }
 
     private void stubSdsError(String path) {
@@ -143,12 +172,26 @@ public class SdsClientComponentTest {
     }
 
     @Test
+    public void callForGetAsidTest() {
+        wireMockServer.resetAll();
+        stubSdsAsidOperation(MIGRATE_STRUCTURED_ID, DEVICE, ResourceReader.asString(sdsDeviceResponse));
+
+        assertEquals("ASIDs are not equal",
+                     "928942012545",
+                     sdsClient.callForGetAsid(MIGRATE_STRUCTURED_INTERACTION, FROM_ODS_CODE, X_CORRELATION_ID
+        ));
+
+        wireMockServer.resetAll();
+    }
+
+    @Test
     public void When_SdsReturnsResult_Expect_AddressIsReturned() {
         allInteractions.forEach(pair -> {
             wireMockServer.resetAll();
-            stubSdsOperation(pair.getKey(), "/Endpoint", ResourceReader.asString(sdsEndpointResponse));
-            stubSdsOperation(pair.getKey(), "/Device", ResourceReader.asString(sdsDeviceResponse));
+            stubSdsOperation(pair.getKey(), ENDPOINT, ResourceReader.asString(sdsEndpointResponse));
+            stubSdsOperation(pair.getKey(), DEVICE, ResourceReader.asString(sdsDeviceResponse));
             var retrievedSdsData = pair.getValue().apply(FROM_ODS_CODE, X_CORRELATION_ID).blockOptional();
+
             assertThat(retrievedSdsData)
                 .isNotEmpty()
                 .hasValue(SdsClient.SdsResponseData.builder()
@@ -156,6 +199,7 @@ public class SdsClientComponentTest {
                     .nhsMhsId(NHS_MHS_ID)
                     .nhsSpineAsid(ASID)
                     .build());
+
             wireMockServer.resetAll();
         });
     }
@@ -164,8 +208,8 @@ public class SdsClientComponentTest {
     public void When_SdsEndpointReturnsNoResult_Expect_EmptyResultIsReturned() {
         allInteractions.forEach(pair -> {
             wireMockServer.resetAll();
-            stubSdsOperation(pair.getKey(), "/Endpoint", ResourceReader.asString(sdsNoResultResponse));
-            stubSdsOperation(pair.getKey(), "/Device", ResourceReader.asString(sdsDeviceResponse));
+            stubSdsOperation(pair.getKey(), ENDPOINT, ResourceReader.asString(sdsNoResultResponse));
+            stubSdsOperation(pair.getKey(), DEVICE, ResourceReader.asString(sdsDeviceResponse));
             assertThatThrownBy(() -> pair.getValue().apply(FROM_ODS_CODE, X_CORRELATION_ID).block())
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("SDS returned no result");
@@ -177,8 +221,9 @@ public class SdsClientComponentTest {
     public void When_SdsReturnsEmptyAddress_Expect_EmptyResultIsReturned() {
         allInteractions.forEach(pair -> {
             wireMockServer.resetAll();
-            stubSdsOperation(pair.getKey(), "/Endpoint", ResourceReader.asString(sdsEndpointNoAddressResponse));
-            stubSdsOperation(pair.getKey(), "/Device", ResourceReader.asString(sdsDeviceResponse));
+            stubSdsOperation(pair.getKey(), ENDPOINT, ResourceReader.asString(sdsEndpointNoAddressResponse));
+            stubSdsOperation(pair.getKey(), DEVICE, ResourceReader.asString(sdsDeviceResponse));
+
             assertThatThrownBy(() -> pair.getValue().apply(FROM_ODS_CODE, X_CORRELATION_ID).block())
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("SDS returned a result but with an empty address");
@@ -190,8 +235,8 @@ public class SdsClientComponentTest {
     public void When_SdsDeviceReturnsNoResults_Expect_EmptyResultIsReturned() {
         allInteractions.forEach(pair -> {
             wireMockServer.resetAll();
-            stubSdsOperation(pair.getKey(), "/Endpoint", ResourceReader.asString(sdsEndpointResponse));
-            stubSdsOperation(pair.getKey(), "/Device", ResourceReader.asString(sdsNoResultResponse));
+            stubSdsOperation(pair.getKey(), ENDPOINT, ResourceReader.asString(sdsEndpointResponse));
+            stubSdsOperation(pair.getKey(), DEVICE, ResourceReader.asString(sdsNoResultResponse));
             assertThatThrownBy(() -> pair.getValue().apply(FROM_ODS_CODE, X_CORRELATION_ID).block())
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("SDS returned no result");
@@ -203,8 +248,8 @@ public class SdsClientComponentTest {
     public void When_SdsReturnsError_Expect_Exception() {
         allInteractions.forEach(pair -> {
             wireMockServer.resetAll();
-            stubSdsError("/Endpoint");
-            stubSdsError("/Device");
+            stubSdsError(ENDPOINT);
+            stubSdsError(DEVICE);
             assertThatThrownBy(() -> pair.getValue().apply(FROM_ODS_CODE, X_CORRELATION_ID).blockOptional())
                 .isInstanceOf(SdsException.class);
             wireMockServer.resetAll();
@@ -215,8 +260,8 @@ public class SdsClientComponentTest {
     public void When_NoXCorrelationIdPresent_Expect_Exception() {
         allInteractions.forEach(pair -> {
             wireMockServer.resetAll();
-            stubSdsError("/Endpoint");
-            stubSdsError("/Device");
+            stubSdsError(ENDPOINT);
+            stubSdsError(DEVICE);
             assertThatThrownBy(() -> pair.getValue().apply(FROM_ODS_CODE, null).blockOptional())
                 .isInstanceOf(SdsException.class);
             wireMockServer.resetAll();
@@ -227,8 +272,8 @@ public class SdsClientComponentTest {
     public void When_InvalidXCorrelationId_Expect_Exception() {
         allInteractions.forEach(pair -> {
             wireMockServer.resetAll();
-            stubSdsError("/Endpoint");
-            stubSdsError("/Device");
+            stubSdsError(ENDPOINT);
+            stubSdsError(DEVICE);
             assertThatThrownBy(() -> pair.getValue().apply(FROM_ODS_CODE, "not-UUID").blockOptional())
                 .isInstanceOf(SdsException.class);
             wireMockServer.resetAll();

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClientComponentTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClientComponentTest.java
@@ -12,7 +12,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.springframework.test.util.AssertionErrors.assertEquals;
-import static uk.nhs.adaptors.gpc.consumer.gpc.InteractionIds.MIGRATE_STRUCTURED_ID;
 
 import java.util.List;
 import java.util.UUID;
@@ -25,6 +24,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -171,14 +172,16 @@ public class SdsClientComponentTest {
                 .withBody(ResourceReader.asString(sdsErrorResponse))));
     }
 
-    @Test
-    public void callForGetAsidTest() {
+    @ParameterizedTest
+    @ValueSource(strings = {MIGRATE_STRUCTURED_INTERACTION, MIGRATE_DOCUMENT_INTERACTION, RETRIEVE_DOCUMENT_INTERACTION,
+                            SEARCH_FOR_DOCUMENT_INTERACTION, GET_STRUCTURED_INTERACTION, PATIENT_SEARCH_ACCESS_DOCUMENT_INTERACTION})
+    public void callForGetAsidTest(String interactionId) {
         wireMockServer.resetAll();
-        stubSdsAsidOperation(MIGRATE_STRUCTURED_ID, DEVICE, ResourceReader.asString(sdsDeviceResponse));
+        stubSdsAsidOperation(interactionId, DEVICE, ResourceReader.asString(sdsDeviceResponse));
 
         assertEquals("ASIDs are not equal",
                      "928942012545",
-                     sdsClient.callForGetAsid(MIGRATE_STRUCTURED_INTERACTION, FROM_ODS_CODE, X_CORRELATION_ID
+                     sdsClient.callForGetAsid(interactionId, FROM_ODS_CODE, X_CORRELATION_ID
         ));
 
         wireMockServer.resetAll();

--- a/service/src/intTest/resources/application.yml
+++ b/service/src/intTest/resources/application.yml
@@ -33,3 +33,4 @@ gpc-consumer:
   sds:
     url: ${GPC_CONSUMER_SDS_URL:}
     apiKey: ${GPC_CONSUMER_SDS_APIKEY:}
+    supplierOdsCode: ${GPC_SUPPLIER_ODS_CODE:XYZ222}

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SdsFilter.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SdsFilter.java
@@ -66,6 +66,7 @@ public class SdsFilter implements GlobalFilter, Ordered {
 
             return chain.filter(mutatedExchange);
         }
+
         return chain.filter(exchange);
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SdsFilter.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SdsFilter.java
@@ -47,6 +47,7 @@ import uk.nhs.adaptors.gpc.consumer.utils.QueryParamsEncoder;
 @Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class SdsFilter implements GlobalFilter, Ordered {
+
     public static final int SDS_FILTER_ORDER = RouteToRequestUrlFilter.ROUTE_TO_URL_FILTER_ORDER + 1;
     public static final String SSP_INTERACTION_ID = "Ssp-InteractionID";
     private static final String DOCUMENT_REFERENCE_SUFFIX = "/DocumentReference";
@@ -55,35 +56,51 @@ public class SdsFilter implements GlobalFilter, Ordered {
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-        SdsClient.SdsResponseData response = getSdsResponseData(exchange);
-        if (response != null) {
-            ServerWebExchange mutatedExchange = appendSspToHeaderIfNeeded(exchange, response.getNhsSpineAsid());
+
+        SdsClient.SdsResponseData gpcProviderEndpointDetails = getGpcProviderEndpointDetails(exchange);
+
+        if (gpcProviderEndpointDetails != null) {
+            String gpcConsumerAsid = getGpcConsumerAsid(exchange);
+            ServerWebExchange mutatedExchange = appendSspHeaderWhenAbsent(exchange, gpcProviderEndpointDetails.getNhsSpineAsid(), "Ssp-To");
+            mutatedExchange = appendSspHeaderWhenAbsent(mutatedExchange, gpcConsumerAsid, "Ssp-From");
+
             return chain.filter(mutatedExchange);
         }
         return chain.filter(exchange);
     }
 
+    private String getGpcConsumerAsid(ServerWebExchange exchange) {
+        LoggingUtil.info(LOGGER, exchange, "Using SDS API to fetch GPC consumer ASID value");
+
+        var odsCode = extractOrganisation(exchange.getRequest().getPath());
+        var correlationId = extractSspTraceId(exchange.getRequest().getHeaders());
+        var interactionId = extractInteractionId(exchange.getRequest().getHeaders());
+
+        return sdsClient.callForGetAsid(interactionId.get(), odsCode, correlationId);
+    }
+
     @NotNull
-    private ServerWebExchange appendSspToHeaderIfNeeded(ServerWebExchange exchange, String asid) {
-        List<String> sspToHeader = exchange.getRequest().getHeaders().get("Ssp-To");
+    private ServerWebExchange appendSspHeaderWhenAbsent(ServerWebExchange exchange, String asid, String sspHeader) {
 
-        String sspTo = asid;
+        List<String> incomingSspHeaderValue = exchange.getRequest().getHeaders().get(sspHeader);
+        String ssp = asid;
 
-        if (sspToHeader != null) {
-            sspTo = sspToHeader.stream().findFirst().orElse(asid);
+        if (incomingSspHeaderValue != null) {
+            ssp = incomingSspHeaderValue.stream().findFirst().orElse(asid);
         }
 
         ServerHttpRequest mutateRequest = exchange.getRequest()
             .mutate()
-            .header("Ssp-To", sspTo)
+            .header(sspHeader, ssp)
             .build();
 
         return exchange.mutate().request(mutateRequest).build();
     }
 
     @Nullable
-    private SdsClient.SdsResponseData getSdsResponseData(ServerWebExchange exchange) {
-        return processSdsResponse(exchange)
+    private SdsClient.SdsResponseData getGpcProviderEndpointDetails(ServerWebExchange exchange) {
+
+        return performGpcProviderSdsLookup(exchange)
             .doOnNext(v -> {
                 if (exchange.getRequest().getPath().value().endsWith(DOCUMENT_REFERENCE_SUFFIX)) {
                     QueryParamsEncoder.encodeQueryParams(exchange);
@@ -92,10 +109,12 @@ public class SdsFilter implements GlobalFilter, Ordered {
     }
 
     @NotNull
-    private Mono<SdsClient.SdsResponseData> processSdsResponse(ServerWebExchange exchange) {
-        LoggingUtil.info(LOGGER, exchange, "Using SDS API for service discovery");
+    private Mono<SdsClient.SdsResponseData> performGpcProviderSdsLookup(ServerWebExchange exchange) {
+
+        LoggingUtil.info(LOGGER, exchange, "Using SDS API for GP connect provider service lookup");
+
         var id = extractInteractionId(exchange.getRequest().getHeaders());
-        return proceedSdsLookup(exchange, id.get());
+        return performGpcProviderSdsLookup(exchange, id.get());
     }
 
     @Override
@@ -127,14 +146,16 @@ public class SdsFilter implements GlobalFilter, Ordered {
         return Optional.empty();
     }
 
-    private Mono<SdsClient.SdsResponseData> proceedSdsLookup(ServerWebExchange exchange, String integrationId) {
+    private Mono<SdsClient.SdsResponseData> performGpcProviderSdsLookup(ServerWebExchange exchange, String interactionId) {
+
         ServerHttpRequest serverHttpRequest = exchange.getRequest();
         String organisation = extractOrganisation(serverHttpRequest.getPath());
         var sspTraceId = extractSspTraceId(exchange.getRequest().getHeaders());
-        return performRequestAccordingToInteractionId(integrationId, organisation, sspTraceId, exchange)
+
+        return performRequestAccordingToInteractionId(interactionId, organisation, sspTraceId, exchange)
             .switchIfEmpty(Mono.error(new SdsException(
                 String.format("No endpoint found in SDS for GP Connect endpoint InteractionId=%s OdsCode=%s",
-                    integrationId,
+                    interactionId,
                     organisation)))
             ).doOnNext(response -> {
                 LoggingUtil.info(LOGGER, exchange, "Found GP connect provider endpoint in sds: {}", response.getAddress());

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SspFilter.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SspFilter.java
@@ -20,6 +20,7 @@ import uk.nhs.adaptors.gpc.consumer.gpc.GpcConfiguration;
 @Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class SspFilter implements GlobalFilter, Ordered {
+
     static final int SSP_FILTER_ORDER = SdsFilter.SDS_FILTER_ORDER + 1;
 
     private final GpcConfiguration gpcConfiguration;

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClient.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClient.java
@@ -94,7 +94,7 @@ public class SdsClient {
 
     private String retrieveAsDeviceNhsSpineAsid(RequestHeadersSpec<? extends RequestHeadersSpec<?>> request) {
 
-        LOGGER.info("Using SDS Device endpoint to retrieve GPC provider Spine ASID");
+        LOGGER.info("Using SDS Device endpoint to retrieve Spine ASID");
 
         return performRequest(request)
             .map(bodyString -> fhirParser.parseResource(Bundle.class, bodyString))

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClient.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClient.java
@@ -93,7 +93,9 @@ public class SdsClient {
     }
 
     private String retrieveAsDeviceNhsSpineAsid(RequestHeadersSpec<? extends RequestHeadersSpec<?>> request) {
+
         LOGGER.info("Using SDS Device endpoint to retrieve GPC provider Spine ASID");
+
         return performRequest(request)
             .map(bodyString -> fhirParser.parseResource(Bundle.class, bodyString))
             .map(bundle -> {

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/utils/QueryParamsEncoder.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/utils/QueryParamsEncoder.java
@@ -20,6 +20,7 @@ public final class QueryParamsEncoder {
 
         if (attributes.containsKey(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR)) {
             MultiValueMap<String, String> encodedParams = new LinkedMultiValueMap<>();
+
             exchange.getRequest().getQueryParams().forEach(
                 (key, values) -> values.forEach(
                     value -> encodedParams.add(UriUtils.encode(key, StandardCharsets.UTF_8),

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -34,3 +34,5 @@ gpc-consumer:
   sds:
     url: ${GPC_CONSUMER_SDS_URL:}
     apiKey: ${GPC_CONSUMER_SDS_APIKEY:}
+    supplierOdsCode: ${GPC_SUPPLIER_ODS_CODE:}
+

--- a/service/src/test/java/uk/nhs/adaptors/gpc/consumer/QueryParamsEncoderTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gpc/consumer/QueryParamsEncoderTest.java
@@ -28,6 +28,7 @@ import uk.nhs.adaptors.gpc.consumer.utils.QueryParamsEncoder;
 
 @ExtendWith(MockitoExtension.class)
 public class QueryParamsEncoderTest {
+
     private static final String FIRST_PARAM = "first";
     private static final String SECOND_PARAM = "second";
     private static final String TEST_URI = "http://www.testhost.com";
@@ -72,6 +73,7 @@ public class QueryParamsEncoderTest {
     public void When_EncodingUri_Expect_UriWithProperlyEncodedParams(String inputUri,
             MultiValueMap<String, String> queryParams,
             String outputUri) {
+
         when(serverHttpRequest.getQueryParams()).thenReturn(queryParams);
 
         ATTRIBUTES.put(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR, prepareUri(inputUri, queryParams));

--- a/service/src/test/java/uk/nhs/adaptors/gpc/consumer/gpc/SdsFilterTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gpc/consumer/gpc/SdsFilterTest.java
@@ -1,0 +1,101 @@
+package uk.nhs.adaptors.gpc.consumer.gpc;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import uk.nhs.adaptors.gpc.consumer.filters.SdsFilter;
+import uk.nhs.adaptors.gpc.consumer.sds.SdsClient;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SdsFilterTest {
+
+    @Mock
+    private SdsClient sdsClient;
+    private SdsFilter sdsFilter;
+    private GatewayFilterChain filterChain;
+    private ArgumentCaptor<ServerWebExchange> captor;
+
+    private static final String MIGRATE_STRUCTURED_INTERACTION
+                                                    = "urn:nhs:names:services:gpconnect:fhir:operation:gpc.migratestructuredrecord-1";
+
+    @BeforeEach
+    @SneakyThrows
+    public void before() {
+        sdsFilter = new SdsFilter(sdsClient);
+        sdsFilter.initializeSdsRequestFunctions();
+
+        filterChain = Mockito.mock(GatewayFilterChain.class);
+        captor = ArgumentCaptor.forClass(ServerWebExchange.class);
+        when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_NoSspHeaders_Expect_FetchValuesFromSds() {
+
+        String odsCode = "A12345";
+        String correlationId = "98765";
+        String gpConnectServerAsid = "928940000057";
+        String gpConnectConsumerAsid = "928942012545";
+
+        MockServerHttpRequest request
+                        = MockServerHttpRequest.get("/A12345/STU3/1/gpconnect/fhir/Patient/$gpc.migratestructuredrecord")
+                        .header("Ssp-TraceID", correlationId)
+                        .header("Ssp-InteractionID",
+                                "urn:nhs:names:services:gpconnect:fhir:operation:gpc.migratestructuredrecord-1").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        when(sdsClient.callForGetAsid(MIGRATE_STRUCTURED_INTERACTION, odsCode, correlationId)).thenReturn(gpConnectConsumerAsid);
+        when(sdsClient.callForMigrateStructuredRecord(odsCode, correlationId))
+                                    .thenReturn(Mono.just(SdsClient.SdsResponseData.builder().nhsSpineAsid(gpConnectServerAsid).build()));
+
+        sdsFilter.filter(exchange, filterChain);
+
+        var resultExchange = captor.getValue();
+        assertEquals(gpConnectConsumerAsid, resultExchange.getRequest().getHeaders().get("ssp-From").get(0));
+        assertEquals(gpConnectServerAsid, resultExchange.getRequest().getHeaders().get("ssp-To").get(0));
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_SspValuesHeadersPresent_Expect_FetchSspValuesFromRequestHeaders() {
+
+        String odsCode = "A12345";
+        String correlationId = "98765";
+        String gpConnectServerAsid = "928940000001";
+        String gpConnectConsumerAsid = "928940000005";
+
+        MockServerHttpRequest request
+            = MockServerHttpRequest.get("/A12345/STU3/1/gpconnect/fhir/Patient/$gpc.migratestructuredrecord")
+            .header("Ssp-TraceID", correlationId)
+            .header("Ssp-InteractionID",
+                    "urn:nhs:names:services:gpconnect:fhir:operation:gpc.migratestructuredrecord-1")
+            .header("Ssp-To", gpConnectServerAsid)
+            .header("Ssp-From", gpConnectConsumerAsid)
+            .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        when(sdsClient.callForGetAsid(MIGRATE_STRUCTURED_INTERACTION, odsCode, correlationId)).thenReturn("928942012545");
+        when(sdsClient.callForMigrateStructuredRecord(odsCode, correlationId))
+            .thenReturn(Mono.just(SdsClient.SdsResponseData.builder().nhsSpineAsid("928940000057").build()));
+
+        sdsFilter.filter(exchange, filterChain);
+
+        var resultExchange = captor.getValue();
+        assertEquals(gpConnectConsumerAsid, resultExchange.getRequest().getHeaders().get("ssp-From").get(0));
+        assertEquals(gpConnectServerAsid, resultExchange.getRequest().getHeaders().get("ssp-To").get(0));
+    }
+
+}

--- a/service/src/test/java/uk/nhs/adaptors/gpc/consumer/gpc/SspFilterTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gpc/consumer/gpc/SspFilterTest.java
@@ -21,12 +21,14 @@ import uk.nhs.adaptors.gpc.consumer.filters.SspFilter;
 
 @ExtendWith(MockitoExtension.class)
 public class SspFilterTest {
+
     private static final String ORIGINAL_RELATIVE_PATH = "https://myhost.com/some/path/here";
     private static final String SSP_URL_NO_TRAILING_SLASH = "https://ssp.com";
     private static final String SSP_URL_WITH_TRAILING_SLASH = SSP_URL_NO_TRAILING_SLASH + "/";
 
     @Mock
     private ServerWebExchange exchange;
+
     @Mock
     private GatewayFilterChain chain;
     private SspFilter sspFilter;
@@ -50,8 +52,9 @@ public class SspFilterTest {
 
         sspFilter.filter(exchange, chain);
 
-        assertThat(attributes.get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR))
-            .isEqualTo(new URI(SSP_URL_WITH_TRAILING_SLASH + ORIGINAL_RELATIVE_PATH));
+        assertThat(attributes)
+            .containsEntry(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR,
+                           new URI(SSP_URL_WITH_TRAILING_SLASH + ORIGINAL_RELATIVE_PATH));
     }
 
     @Test
@@ -61,8 +64,9 @@ public class SspFilterTest {
 
         sspFilter.filter(exchange, chain);
 
-        assertThat(attributes.get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR))
-            .isEqualTo(new URI(SSP_URL_WITH_TRAILING_SLASH + ORIGINAL_RELATIVE_PATH));
+        assertThat(attributes)
+            .containsEntry(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR,
+                           new URI(SSP_URL_WITH_TRAILING_SLASH + ORIGINAL_RELATIVE_PATH));
     }
 
 }


### PR DESCRIPTION
The aim of this PR is to address an issue when "Ssp-From" header is not set correctly in GP Connect.
With this PR we fetch ASID based on interactionID, ODS code and correlationID and then set it as "Ssp-From" header and use it while querying SDS service