### PR TITLE
Upgrade from jdk-11.0.11+9 to jdk-11.0.21+9

### DIFF
--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -10,7 +10,7 @@ FROM build AS package
 
 RUN gradle --build-cache bootJar
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre-focal
 
 EXPOSE 8080
 


### PR DESCRIPTION
The adoptopenjdk images have been deprecated since 2021-08-01 in favour of eclipse-temurin.

This should bring in the latest security fixes.

The focal image appears to be a suitable replacement as it is also based on Ubuntu 20.04