### PR TITLE
Upgrade lombok from 1.18.16 to 1.18.26

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !service/config
 !service/src
 !service/build.gradle
+!service/lombok.config
 !service/settings.gradle
 !gpcc-mocks/config
 !gpcc-mocks/src

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-lombok.config
 
 ### NetBeans ###
 /nbproject/private/

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id "java"
 	id "checkstyle"
 	id "com.github.spotbugs" version "4.7.0"
-	id "io.freefair.lombok" version "5.3.0"
+	id "io.freefair.lombok" version "6.6.3"
 	id "jacoco"
 }
 
@@ -23,10 +23,6 @@ repositories {
 
 ext {
 	set("springCloudVersion", "2021.0.1")
-}
-
-lombok {
-	config["lombok.log.fieldName"] = "LOGGER"
 }
 
 dependencies {

--- a/service/lombok.config
+++ b/service/lombok.config
@@ -1,0 +1,4 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true
+lombok.extern.findbugs.addSuppressFBWarnings = true
+lombok.log.fieldName = LOGGER


### PR DESCRIPTION
1.18.22 adds support for Java 17
See: https://projectlombok.org/changelog

Version 6 of io.freefair.lombok does not generate the config file automatically.
Instead commit the generated version from 5.3.
See: freefair/gradle-plugins#379