### PR TITLE
Update Spring Framework from 5.3.18 to 5.3.31

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id "org.springframework.boot" version "2.6.6"
+	id "org.springframework.boot" version "2.7.18"
 	id "io.spring.dependency-management" version "1.0.11.RELEASE"
 	id "java"
 	id "checkstyle"
@@ -22,7 +22,7 @@ repositories {
 }
 
 ext {
-	set("springCloudVersion", "2021.0.1")
+	set("springCloudVersion", "2021.0.9")
 }
 
 dependencies {


### PR DESCRIPTION
Resolves 7 high, and 1 critical CVE.