### PR TITLE
Remove calls to .block() which are made from within reactor threads

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClientComponentTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClientComponentTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gpc.consumer.sds;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -13,7 +14,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static org.springframework.test.util.AssertionErrors.assertEquals;
 
 import java.util.List;
 import java.util.UUID;
@@ -186,10 +186,10 @@ public class SdsClientComponentTest {
         ReflectionTestUtils.setField(sdsClient, "supplierOdsCode", SUPPLIER_ODS_CODE);
         stubSdsAsidOperation(interactionId, DEVICE, ResourceReader.asString(sdsDeviceResponse));
 
-        assertEquals("ASIDs are not equal",
-                     "928942012545",
-                     sdsClient.callForGetAsid(interactionId, FROM_ODS_CODE, X_CORRELATION_ID
-        ));
+        assertEquals(
+            "928942012545",
+            sdsClient.callForGetAsid(interactionId, FROM_ODS_CODE, X_CORRELATION_ID).block()
+        );
 
         wireMockServer.resetAll();
     }

--- a/service/src/test/java/uk/nhs/adaptors/gpc/consumer/gpc/SdsFilterTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gpc/consumer/gpc/SdsFilterTest.java
@@ -57,11 +57,11 @@ public class SdsFilterTest {
                                 "urn:nhs:names:services:gpconnect:fhir:operation:gpc.migratestructuredrecord-1").build();
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
-        when(sdsClient.callForGetAsid(MIGRATE_STRUCTURED_INTERACTION, odsCode, correlationId)).thenReturn(gpConnectConsumerAsid);
+        when(sdsClient.callForGetAsid(MIGRATE_STRUCTURED_INTERACTION, odsCode, correlationId)).thenReturn(Mono.just(gpConnectConsumerAsid));
         when(sdsClient.callForMigrateStructuredRecord(odsCode, correlationId))
                                     .thenReturn(Mono.just(SdsClient.SdsResponseData.builder().nhsSpineAsid(gpConnectServerAsid).build()));
 
-        sdsFilter.filter(exchange, filterChain);
+        sdsFilter.filter(exchange, filterChain).block();
 
         var resultExchange = captor.getValue();
         assertEquals(gpConnectConsumerAsid, resultExchange.getRequest().getHeaders().get("ssp-From").get(0));
@@ -87,11 +87,11 @@ public class SdsFilterTest {
             .build();
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
-        when(sdsClient.callForGetAsid(MIGRATE_STRUCTURED_INTERACTION, odsCode, correlationId)).thenReturn("928942012545");
+        when(sdsClient.callForGetAsid(MIGRATE_STRUCTURED_INTERACTION, odsCode, correlationId)).thenReturn(Mono.just("928942012545"));
         when(sdsClient.callForMigrateStructuredRecord(odsCode, correlationId))
             .thenReturn(Mono.just(SdsClient.SdsResponseData.builder().nhsSpineAsid("928940000057").build()));
 
-        sdsFilter.filter(exchange, filterChain);
+        sdsFilter.filter(exchange, filterChain).block();
 
         var resultExchange = captor.getValue();
         assertEquals(gpConnectConsumerAsid, resultExchange.getRequest().getHeaders().get("ssp-From").get(0));


### PR DESCRIPTION
This change will allow our code to work with reactor-core version 3.2

See: https://github.com/reactor/reactor-core/releases/tag/v3.2.0.M2