### PR TITLE
Upgrade from Java 17 -> 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The adaptor does not perform a PDS lookup/trace. You must perform the PDS lookup
 
 ## Requirements
 
-* JDK 17
+* JDK 21
 * Docker
 
 ## Configuration

--- a/docker/gpcc-mocks/Dockerfile
+++ b/docker/gpcc-mocks/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.7-jdk17 AS build
+FROM gradle:8.7-jdk21 AS build
 
 COPY --chown=gradle:gradle gpcc-mocks /home/gradle/gpcc-mocks
 
@@ -10,7 +10,7 @@ FROM build AS package
 
 RUN gradle --build-cache bootJar
 
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
 EXPOSE 8081
 

--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.7-jdk17 AS build
+FROM gradle:8.7-jdk21 AS build
 
 COPY --chown=gradle:gradle service /home/gradle/service
 
@@ -10,7 +10,7 @@ FROM build AS package
 
 RUN gradle --build-cache bootJar
 
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
 EXPOSE 8080
 

--- a/gpcc-mocks/build.gradle
+++ b/gpcc-mocks/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'uk.nhs.adaptors'
-sourceCompatibility = '17'
+sourceCompatibility = '21'
 
 configurations {
 	compileOnly {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply plugin: "checkstyle"
 apply plugin: "com.github.spotbugs"
 
 group = "uk.nhs.adaptors"
-sourceCompatibility = "17"
+sourceCompatibility = "21"
 
 repositories {
 	mavenCentral()


### PR DESCRIPTION
## Why

Gives us a couple of years of Long Term Support, and some new features in Java.