### PR TITLE
Do not publish docker images if a PR raised by Dependabot

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -221,6 +221,7 @@ jobs:
                     repository: gpc-consumer
                     build-context: .
 
+      if: github.actor != 'dependabot[bot]'
       steps:
           - name: Checkout Repository
             uses: actions/checkout@v4


### PR DESCRIPTION
Dependabot doesn't have an access to secrets hence "build-and-publish-docker-images" task fails since it requires an access to secrets. Actually, we don't need to push the image immediately hence we can skip this step.