### PR TITLE
GPC Configuration property `structuredFhirBasePathRegex` is defined but not used

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfiguration.java
@@ -15,6 +15,5 @@ public class GpcConfiguration {
     private String clientKey;
     private String rootCA;
     private String subCA;
-    private String structuredFhirBasePathRegex;
     private String sspUrl;
 }


### PR DESCRIPTION
* Remove `structuredFhirBasePathRegex` from `GpcConfiguration` as this is not bound to any configuration variables and is not used anywhere.