### PR TITLE
NIAD-3171 - GP Consumer Adaptor should error if any of the required GPC_CONSUMER environment variables are missing

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
@@ -135,15 +135,14 @@ public class GpcConfigurationValidationTest {
             )
             .run(context -> {
                 assertThat(context).hasFailed();
-
                 var startupFailure = context.getStartupFailure();
 
                 assertThat(startupFailure)
                     .rootCause()
+                    .hasMessageContaining("To enable mutual TLS you must provide GPC_CONSUMER_SPINE_CLIENT_CERT environment variable(s).")
                     .hasMessageContaining(
-                        "Either all or none of the GPC_CONSUMER_SPINE_ variables must be defined. "
-                            + "Missing variables: GPC_CONSUMER_SPINE_CLIENT_CERT"
-                    );
+                         "To disable mutual TLS you must remove GPC_CONSUMER_SPINE_CLIENT_KEY, GPC_CONSUMER_SPINE_ROOT_CA_CERT, "
+                             + "GPC_CONSUMER_SPINE_SUB_CA_CERT environment variable(s).");
             });
     }
 
@@ -164,8 +163,7 @@ public class GpcConfigurationValidationTest {
                 assertThat(startupFailure)
                     .rootCause()
                     .hasMessageContaining(
-                        "One or more of the GPC_CONSUMER_SPINE_ variables is in an invalid PEM format. "
-                            + "Invalid variables: GPC_CONSUMER_SPINE_CLIENT_CERT"
+                        "The environment variable(s) GPC_CONSUMER_SPINE_CLIENT_CERT are not in a valid PEM format"
                     );
             });
     }
@@ -187,8 +185,7 @@ public class GpcConfigurationValidationTest {
                 assertThat(startupFailure)
                     .rootCause()
                     .hasMessageContaining(
-                        "One or more of the GPC_CONSUMER_SPINE_ variables is in an invalid PEM format. "
-                            + "Invalid variables: GPC_CONSUMER_SPINE_CLIENT_KEY"
+                        "The environment variable(s) GPC_CONSUMER_SPINE_CLIENT_KEY are not in a valid PEM format"
                     );
             });
     }

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
@@ -4,14 +4,12 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@SpringBootTest
 public class GpcConfigurationValidationTest {
 
     private static final String VALID_CERTIFICATE =

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
@@ -1,0 +1,259 @@
+package uk.nhs.adaptors.gpc.consumer.gpc;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+public class GpcConfigurationValidationTest {
+
+    public static final String VALID_CERTIFICATE =
+        """
+            -----BEGIN CERTIFICATE-----
+            MIIDhzCCAm+gAwIBAgIESK+5NTANBgkqhkiG9w0BAQsFADBbMScwJQYDVQQDDB5SZWdlcnkgU2Vs
+            Zi1TaWduZWQgQ2VydGlmaWNhdGUxIzAhBgNVBAoMGlJlZ2VyeSwgaHR0cHM6Ly9yZWdlcnkuY29t
+            MQswCQYDVQQGEwJVQTAgFw0yNTAxMjAwMDAwMDBaGA8yMTI1MDEyMDEwMzYyNVowSTEVMBMGA1UE
+            AwwMdGVzdC1zc2wuY29tMSMwIQYDVQQKDBpSZWdlcnksIGh0dHBzOi8vcmVnZXJ5LmNvbTELMAkG
+            A1UEBhMCVUEwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCgTdIL7LEaTBbQiAziGocB
+            gGNXBHHY5f8Rjit4FS+l12VR/Q9CcZU8nTc6V2mqPyxbgS/ATxpaWTPHbNGy/1VRWij1OCOTwFB2
+            dBKKFKfIPya3JCY7RYKbvEH+Nrgc0fwJ3dqQ9Cv5w8oIsuM8HS34Y9mr/KlfpWc9fLxTDTmHCf4a
+            /rYdRxQZfLwg2zi4rHaURn9T/S0jZMT0rwETajgnQl5WPfDV4d3Wslkz6ohEcQnvpDfB6mRSqA+C
+            iFgOBDEnREW6UsEFX/kPP9O64HAQzrMwdlPso3BiVMO/rgZ2VX709vj1Wti1hJARwZeMfg0fXLnE
+            MfRvUqoYm1mxSpc5AgMBAAGjYzBhMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMB0G
+            A1UdDgQWBBQdR0XRwEDaOUdmKm21TXPncLJDhDAfBgNVHSMEGDAWgBQdR0XRwEDaOUdmKm21TXPn
+            cLJDhDANBgkqhkiG9w0BAQsFAAOCAQEAMqf4IhZEBCcJx8TiHLNDc3AMpy49xBVZ7ANgd4cKjcSa
+            L4sBFuT39ARn+SvFP76sNPDCzZC+xDsDLPgd4Jwweyko8hjYk02MR7FpdzlUPbVsPvfwJ1ynAb71
+            VWWmvULKmXvPkOJkqdGnB2k89SXH80wMnl6YErXX3w6N3HOFjYUdyTWZmwCJ/MOBwDyOb3i8fcY+
+            td+K1KtqWBrntnTic+4y2inBgI+Wipf3a+EbwbzkgU01EgTaCykhkoh7fZfNwQ5VGY+AcyNbd0xX
+            WjDDOYAag96BLBMAgvjZqFl67tL+/CNO9o4YEPZ7pg0FvI3/Xp9L3edXvvzLREbaHxCnjQ==
+            -----END CERTIFICATE-----""";
+
+    public static final String VALID_RSA_PRIVATE_KEY =
+        """
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEowIBAAKCAQEAoE3SC+yxGkwW0IgM4hqHAYBjVwRx2OX/EY4reBUvpddlUf0P
+            QnGVPJ03Oldpqj8sW4EvwE8aWlkzx2zRsv9VUVoo9Tgjk8BQdnQSihSnyD8mtyQm
+            O0WCm7xB/ja4HNH8Cd3akPQr+cPKCLLjPB0t+GPZq/ypX6VnPXy8Uw05hwn+Gv62
+            HUcUGXy8INs4uKx2lEZ/U/0tI2TE9K8BE2o4J0JeVj3w1eHd1rJZM+qIRHEJ76Q3
+            wepkUqgPgohYDgQxJ0RFulLBBV/5Dz/TuuBwEM6zMHZT7KNwYlTDv64GdlV+9Pb4
+            9VrYtYSQEcGXjH4NH1y5xDH0b1KqGJtZsUqXOQIDAQABAoIBAAVVEVucL/fz9/5P
+            yD3tK/h80NEgMLlKTUXEOOXxrngRxikIBe3r4U7229Nw/O7Q0yToEzKObw36UaKc
+            mA0gOTJPkXU2vNg5WXPXQJafQUWD9EG7ThpCoamUhY1zPISY541cd9zCgoP4Y0wO
+            x0hEoDbW+3KhIPExi1GcSJdqpTM8sEmzDnFIXylAEYhOVgjvZLt0LhleTzF5qlmG
+            ywfyFJhAhkPXe6AhONKFAsBNFxEse4fljcCijbtzauBrw7K6amd+Rp8j+bwsrAqW
+            a5FLerEnVGKQAugg4oj8q1N6iuTqGWVtO/SSykLgGSEWlW15+X0qJcLDz/XCFR0+
+            ZHN+ypECgYEA44rEcHAWc1MgO3KaVg5ST8TLzwwWTK+Nf0nZ4qhVksZqcxBgTNot
+            y2lF9u03wGwKzn0nqSBJqMYNFNjrGQZ9MDjyflCN3oTKgsVgIKssx26rGojfO5Qh
+            54RBfory/YR3zhGETeF0eW/hbneRLPpEPeGAaJCbaPLLDFJaazHxnUMCgYEAtFpJ
+            SWT92HtLvEqv727/xMX6RXi0jN3l2qo6g46mMn3Vvpsmgq2hK9KrLYNPvi9Z78bo
+            3rKAg2qmcu5aiAOFdiNRh9WAM78+iaJc3OZ6WpWwVUMFxxEh3iM330IiGIJsr4jz
+            ridOUXRVKAoEb7spfZxRZ6QjJG6q+mOrXDD+E9MCgYAHfTC79qR2hTzhWANGY9BH
+            udVvahltyrVghCC8ugee/hLQ2LAit2ecc0mPN/2GwseURkBA68Qg3uvdTMpoF3OV
+            W7p3d9VDhqFXroFcceXWZokRJYIbZuO6x/qT3KTkvTBoQuFU4t+/g3Qq+5p2nYIT
+            e1GLn37N9HfEXw2Ey68FGwKBgQCZF5bkPV0ZeTfFwqRrm45zKxcSB69DcEzf++Yl
+            rF45uAVLggoDnX2VZIO346I6L5mpZvBfsahTZaGbJ+cjU9HjgYGAy2PDCVD9phwr
+            y10LLct75KOv4kQce0q/MjUdFwFJU/h92ZGqpRRwI2i2q2pB3QJg9rx5/ZMXbqmU
+            XWYfzwKBgGyCA1NLMoPKPdaKnYHkoAwi7/ytLsA7IpLCg+NkiA6B7THGh60IpH7B
+            RLwFShJRFGA+z4b1WoGPcmUloSJsMI6EjZDuG1gcWAbENWrcqkMKKJH6f9X/5pIq
+            frOEfuS/2Ie8Rj8PZhhFoekjQHgtzba4w4oqfo1YeBFYc6QH/QKb
+            -----END RSA PRIVATE KEY-----""";
+
+    public static final String INVALID_CERTIFICATE = "------BEGIN CERTIFICATE----- invalid value -----END CERTIFICATE-----";
+    public static final String INVALID_RSA_PRIVATE_KEY = "------BEGIN RSA PRIVATE KEY ----- invalid value -----END RSA PRIVATE KEY-----";
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(TestGpcConfiguration.class);
+
+    @Test
+    void When_GpcConfigurationContainsAllSslProperties_Expect_IsContextIsCreatedAndShouldUseSslIsTrue() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue("clientCert", VALID_CERTIFICATE),
+                buildPropertyValue("clientKey", VALID_RSA_PRIVATE_KEY),
+                buildPropertyValue("rootCA", VALID_CERTIFICATE),
+                buildPropertyValue("subCA", VALID_CERTIFICATE)
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(GpcConfiguration.class);
+
+                var gpcConfiguration = context.getBean(GpcConfiguration.class);
+
+                assertAll(
+                    () -> assertThat(gpcConfiguration.getClientCert()).isEqualTo(VALID_CERTIFICATE),
+                    () -> assertThat(gpcConfiguration.getClientKey()).isEqualTo(VALID_RSA_PRIVATE_KEY),
+                    () -> assertThat(gpcConfiguration.getRootCA()).isEqualTo(VALID_CERTIFICATE),
+                    () -> assertThat(gpcConfiguration.getSubCA()).isEqualTo(VALID_CERTIFICATE),
+                    () -> assertThat(gpcConfiguration.isSslEnabled()).isTrue()
+                );
+            });
+    }
+
+    @Test
+    void When_GpcConfigurationNoSslProperties_Expect_IsContextIsCreatedAndShouldUseSslIsFalse() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue("clientCert", ""),
+                buildPropertyValue("clientKey", ""),
+                buildPropertyValue("rootCA", ""),
+                buildPropertyValue("subCA", "")
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(GpcConfiguration.class);
+
+                var gpcConfiguration = context.getBean(GpcConfiguration.class);
+
+                assertAll(
+                    () -> assertThat(gpcConfiguration.getClientCert()).isEmpty(),
+                    () -> assertThat(gpcConfiguration.getClientKey()).isEmpty(),
+                    () -> assertThat(gpcConfiguration.getRootCA()).isEmpty(),
+                    () -> assertThat(gpcConfiguration.getSubCA()).isEmpty(),
+                    () -> assertThat(gpcConfiguration.isSslEnabled()).isFalse()
+                );
+            });
+    }
+
+    @Test
+    void When_GpcConfigurationHasSomeButNotAllSslProperties_Expect_ContextNotCreated(
+    ) {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue("clientCert", ""),
+                buildPropertyValue("clientKey", VALID_RSA_PRIVATE_KEY),
+                buildPropertyValue("rootCA", VALID_CERTIFICATE),
+                buildPropertyValue("subCA", VALID_CERTIFICATE)
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+
+                var startupFailure = context.getStartupFailure();
+
+                assertThat(startupFailure)
+                    .rootCause()
+                    .hasMessageContaining(
+                        "Either all or none of the GPC_CONSUMER_SPINE_ variables must be defined. "
+                            + "Missing variables: GPC_CONSUMER_SPINE_CLIENT_CERT"
+                    );
+            });
+    }
+
+    @Test
+    void When_GpcConfigurationHasAnInvalidCertificate_Expect_ContextIsNotCreated() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue("clientCert", INVALID_CERTIFICATE),
+                buildPropertyValue("clientKey", VALID_RSA_PRIVATE_KEY),
+                buildPropertyValue("rootCA", VALID_CERTIFICATE),
+                buildPropertyValue("subCA", VALID_CERTIFICATE)
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+
+                var startupFailure = context.getStartupFailure();
+
+                assertThat(startupFailure)
+                    .rootCause()
+                    .hasMessageContaining(
+                        "One or more of the GPC_CONSUMER_SPINE_ variables is in an invalid PEM format. "
+                            + "Invalid variables: GPC_CONSUMER_SPINE_CLIENT_CERT"
+                    );
+            });
+    }
+
+    @Test
+    void When_GpcConfigurationHasAnInvalidClientKey_Expect_ContextIsNotCreated() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue("clientCert", VALID_CERTIFICATE),
+                buildPropertyValue("clientKey", INVALID_RSA_PRIVATE_KEY),
+                buildPropertyValue("rootCA", VALID_CERTIFICATE),
+                buildPropertyValue("subCA", VALID_CERTIFICATE)
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+
+                var startupFailure = context.getStartupFailure();
+
+                assertThat(startupFailure)
+                    .rootCause()
+                    .hasMessageContaining(
+                        "One or more of the GPC_CONSUMER_SPINE_ variables is in an invalid PEM format. "
+                            + "Invalid variables: GPC_CONSUMER_SPINE_CLIENT_KEY"
+                    );
+            });
+    }
+
+    @Test
+    void When_GpcConfigurationHasSspUrlPresentWithTrailingSlash_Expect_ContextIsCreatedAndIsSspEnabled() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue("sspUrl", "/this-is-a-url.com/")
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(GpcConfiguration.class);
+
+                var gpcConfiguration = context.getBean(GpcConfiguration.class);
+                assertThat(gpcConfiguration.isSspEnabled()).isTrue();
+            });
+    }
+
+    @Test
+    void When_GpcConfigurationHasSspUrlPresentWithoutTrailingSlash_Expect_ContextIsCreatedAndIsNotSspUrlHasTrailingSlash() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue("sspUrl", "/this-is-a-url.com")
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(GpcConfiguration.class);
+
+                var gpcConfiguration = context.getBean(GpcConfiguration.class);
+
+                assertAll(
+                    () -> assertThat(gpcConfiguration.isSspEnabled()).isTrue(),
+                    () -> assertThat(gpcConfiguration.getSspUrl()).isEqualTo("/this-is-a-url.com/")
+                );
+            });
+    }
+
+    @Test
+    void When_GpcConfigurationDoesNotHaveSspUrlPresent_Expect_ContextIsCreatedAndIsNotSspEnabled() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue("sspUrl", "")
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(GpcConfiguration.class);
+
+                var gpcConfiguration = context.getBean(GpcConfiguration.class);
+                assertThat(gpcConfiguration.isSspEnabled()).isFalse();
+            });
+    }
+
+    @Contract(pure = true)
+    private static @NotNull String buildPropertyValue(String propertyName, String value) {
+        return String.format("gpc-consumer.gpc.%s=%s", propertyName, value);
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(GpcConfiguration.class)
+    static class TestGpcConfiguration {
+    }
+}
+
+

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @SpringBootTest
 public class GpcConfigurationValidationTest {
 
-    public static final String VALID_CERTIFICATE =
+    private static final String VALID_CERTIFICATE =
         """
             -----BEGIN CERTIFICATE-----
             MIIDhzCCAm+gAwIBAgIESK+5NTANBgkqhkiG9w0BAQsFADBbMScwJQYDVQQDDB5SZWdlcnkgU2Vs
@@ -35,7 +35,7 @@ public class GpcConfigurationValidationTest {
             WjDDOYAag96BLBMAgvjZqFl67tL+/CNO9o4YEPZ7pg0FvI3/Xp9L3edXvvzLREbaHxCnjQ==
             -----END CERTIFICATE-----""";
 
-    public static final String VALID_RSA_PRIVATE_KEY =
+    private static final String VALID_RSA_PRIVATE_KEY =
         """
             -----BEGIN RSA PRIVATE KEY-----
             MIIEowIBAAKCAQEAoE3SC+yxGkwW0IgM4hqHAYBjVwRx2OX/EY4reBUvpddlUf0P
@@ -65,12 +65,12 @@ public class GpcConfigurationValidationTest {
             frOEfuS/2Ie8Rj8PZhhFoekjQHgtzba4w4oqfo1YeBFYc6QH/QKb
             -----END RSA PRIVATE KEY-----""";
 
-    public static final String INVALID_CERTIFICATE = "------BEGIN CERTIFICATE----- invalid value -----END CERTIFICATE-----";
-    public static final String INVALID_RSA_PRIVATE_KEY = "------BEGIN RSA PRIVATE KEY ----- invalid value -----END RSA PRIVATE KEY-----";
-    public static final String CLIENT_CERT = "clientCert";
-    public static final String CLIENT_KEY = "clientKey";
-    public static final String ROOT_CA = "rootCA";
-    public static final String SUB_CA = "subCA";
+    private static final String INVALID_CERTIFICATE = "------BEGIN CERTIFICATE----- invalid value -----END CERTIFICATE-----";
+    private static final String INVALID_RSA_PRIVATE_KEY = "------BEGIN RSA PRIVATE KEY ----- invalid value -----END RSA PRIVATE KEY-----";
+    private static final String CLIENT_CERT = "clientCert";
+    private static final String CLIENT_KEY = "clientKey";
+    private static final String ROOT_CA = "rootCA";
+    private static final String SUB_CA = "subCA";
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withUserConfiguration(TestGpcConfiguration.class);

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
@@ -67,6 +67,10 @@ public class GpcConfigurationValidationTest {
 
     public static final String INVALID_CERTIFICATE = "------BEGIN CERTIFICATE----- invalid value -----END CERTIFICATE-----";
     public static final String INVALID_RSA_PRIVATE_KEY = "------BEGIN RSA PRIVATE KEY ----- invalid value -----END RSA PRIVATE KEY-----";
+    public static final String CLIENT_CERT = "clientCert";
+    public static final String CLIENT_KEY = "clientKey";
+    public static final String ROOT_CA = "rootCA";
+    public static final String SUB_CA = "subCA";
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withUserConfiguration(TestGpcConfiguration.class);
@@ -75,10 +79,10 @@ public class GpcConfigurationValidationTest {
     void When_GpcConfigurationContainsAllSslProperties_Expect_IsContextIsCreatedAndShouldUseSslIsTrue() {
         contextRunner
             .withPropertyValues(
-                buildPropertyValue("clientCert", VALID_CERTIFICATE),
-                buildPropertyValue("clientKey", VALID_RSA_PRIVATE_KEY),
-                buildPropertyValue("rootCA", VALID_CERTIFICATE),
-                buildPropertyValue("subCA", VALID_CERTIFICATE)
+                buildPropertyValue(CLIENT_CERT, VALID_CERTIFICATE),
+                buildPropertyValue(CLIENT_KEY, VALID_RSA_PRIVATE_KEY),
+                buildPropertyValue(ROOT_CA, VALID_CERTIFICATE),
+                buildPropertyValue(SUB_CA, VALID_CERTIFICATE)
             )
             .run(context -> {
                 assertThat(context)
@@ -101,10 +105,10 @@ public class GpcConfigurationValidationTest {
     void When_GpcConfigurationNoSslProperties_Expect_IsContextIsCreatedAndShouldUseSslIsFalse() {
         contextRunner
             .withPropertyValues(
-                buildPropertyValue("clientCert", ""),
-                buildPropertyValue("clientKey", ""),
-                buildPropertyValue("rootCA", ""),
-                buildPropertyValue("subCA", "")
+                buildPropertyValue(CLIENT_CERT, ""),
+                buildPropertyValue(CLIENT_KEY, ""),
+                buildPropertyValue(ROOT_CA, ""),
+                buildPropertyValue(SUB_CA, "")
             )
             .run(context -> {
                 assertThat(context)
@@ -128,10 +132,10 @@ public class GpcConfigurationValidationTest {
     ) {
         contextRunner
             .withPropertyValues(
-                buildPropertyValue("clientCert", ""),
-                buildPropertyValue("clientKey", VALID_RSA_PRIVATE_KEY),
-                buildPropertyValue("rootCA", VALID_CERTIFICATE),
-                buildPropertyValue("subCA", VALID_CERTIFICATE)
+                buildPropertyValue(CLIENT_CERT, ""),
+                buildPropertyValue(CLIENT_KEY, VALID_RSA_PRIVATE_KEY),
+                buildPropertyValue(ROOT_CA, VALID_CERTIFICATE),
+                buildPropertyValue(SUB_CA, VALID_CERTIFICATE)
             )
             .run(context -> {
                 assertThat(context).hasFailed();
@@ -150,10 +154,10 @@ public class GpcConfigurationValidationTest {
     void When_GpcConfigurationHasAnInvalidCertificate_Expect_ContextIsNotCreated() {
         contextRunner
             .withPropertyValues(
-                buildPropertyValue("clientCert", INVALID_CERTIFICATE),
-                buildPropertyValue("clientKey", VALID_RSA_PRIVATE_KEY),
-                buildPropertyValue("rootCA", VALID_CERTIFICATE),
-                buildPropertyValue("subCA", VALID_CERTIFICATE)
+                buildPropertyValue(CLIENT_CERT, INVALID_CERTIFICATE),
+                buildPropertyValue(CLIENT_KEY, VALID_RSA_PRIVATE_KEY),
+                buildPropertyValue(ROOT_CA, VALID_CERTIFICATE),
+                buildPropertyValue(SUB_CA, VALID_CERTIFICATE)
             )
             .run(context -> {
                 assertThat(context).hasFailed();
@@ -172,10 +176,10 @@ public class GpcConfigurationValidationTest {
     void When_GpcConfigurationHasAnInvalidClientKey_Expect_ContextIsNotCreated() {
         contextRunner
             .withPropertyValues(
-                buildPropertyValue("clientCert", VALID_CERTIFICATE),
-                buildPropertyValue("clientKey", INVALID_RSA_PRIVATE_KEY),
-                buildPropertyValue("rootCA", VALID_CERTIFICATE),
-                buildPropertyValue("subCA", VALID_CERTIFICATE)
+                buildPropertyValue(CLIENT_CERT, VALID_CERTIFICATE),
+                buildPropertyValue(CLIENT_KEY, INVALID_RSA_PRIVATE_KEY),
+                buildPropertyValue(ROOT_CA, VALID_CERTIFICATE),
+                buildPropertyValue(SUB_CA, VALID_CERTIFICATE)
             )
             .run(context -> {
                 assertThat(context).hasFailed();

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfiguration.java
@@ -1,19 +1,23 @@
 package uk.nhs.adaptors.gpc.consumer.gpc;
 
+import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-
-import lombok.Getter;
-import lombok.Setter;
+import org.springframework.validation.annotation.Validated;
+import uk.nhs.adaptors.gpc.consumer.gpc.validation.ValidGpcConfiguration;
 
 @Component
 @ConfigurationProperties(prefix = "gpc-consumer.gpc")
-@Getter
-@Setter
+@Data
+@Validated
+@ValidGpcConfiguration
 public class GpcConfiguration {
     private String clientCert;
     private String clientKey;
     private String rootCA;
     private String subCA;
     private String sspUrl;
+
+    private boolean sslEnabled;
+    private boolean sspEnabled;
 }

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/validation/GpcConfigurationValidator.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/validation/GpcConfigurationValidator.java
@@ -1,0 +1,113 @@
+package uk.nhs.adaptors.gpc.consumer.gpc.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import uk.nhs.adaptors.gpc.consumer.gpc.GpcConfiguration;
+import uk.nhs.adaptors.gpc.consumer.utils.PemFormatter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class GpcConfigurationValidator implements ConstraintValidator<ValidGpcConfiguration, GpcConfiguration> {
+
+    private static final String INVALID_FORMAT_VIOLATION_MESSAGE =
+        "One or more of the GPC_CONSUMER_SPINE_ variables is in an invalid PEM format. Invalid variables: %s";
+    private static final String MISSING_SSL_PROPERTIES_VIOLATION_MESSAGE =
+        "Either all or none of the GPC_CONSUMER_SPINE_ variables must be defined. Missing variables: %s";
+    private static final int NUMBER_OF_SSL_PROPERTIES = 4;
+
+    @Override
+    public boolean isValid(GpcConfiguration config, ConstraintValidatorContext context) {
+
+        validateSspUrl(config);
+
+        var missingSslProperties = checkForMissingSslProperties(config);
+        if (missingSslProperties.size() == NUMBER_OF_SSL_PROPERTIES) {
+            config.setSslEnabled(false);
+            return true;
+        }
+        if (!missingSslProperties.isEmpty()) {
+            setConstraintViolation(context, MISSING_SSL_PROPERTIES_VIOLATION_MESSAGE, missingSslProperties);
+            return false;
+        }
+
+        var invalidSslProperties = checkSslPropertiesAreValidPemFormat(config);
+        if (!invalidSslProperties.isEmpty()) {
+            setConstraintViolation(context, INVALID_FORMAT_VIOLATION_MESSAGE, invalidSslProperties);
+            return false;
+        }
+
+        config.setSslEnabled(true);
+        return true;
+    }
+
+    private static void setConstraintViolation(ConstraintValidatorContext context, String message, List<String> violations) {
+        String violationMessage = String.format(message, String.join(", ", violations));
+
+        LOGGER.error(violationMessage);
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(violationMessage).addConstraintViolation();
+    }
+
+    private List<String> checkForMissingSslProperties(GpcConfiguration config) {
+        var missingSslProperty = new ArrayList<String>();
+
+        if (StringUtils.isBlank(config.getClientCert())) {
+            missingSslProperty.add("GPC_CONSUMER_SPINE_CLIENT_CERT");
+        }
+        if (StringUtils.isBlank(config.getClientKey())) {
+            missingSslProperty.add("GPC_CONSUMER_SPINE_CLIENT_KEY");
+        }
+        if (StringUtils.isBlank(config.getRootCA())) {
+            missingSslProperty.add("GPC_CONSUMER_SPINE_ROOT_CA_CERT");
+        }
+        if (StringUtils.isBlank(config.getSubCA())) {
+            missingSslProperty.add("GPC_CONSUMER_SPINE_SUB_CA_CERT");
+        }
+
+        return missingSslProperty;
+    }
+
+    private List<String> checkSslPropertiesAreValidPemFormat(GpcConfiguration config) {
+        var invalidSslProperties = new ArrayList<String>();
+
+        if (isInvalidPemFormat(config.getClientCert())) {
+            invalidSslProperties.add("GPC_CONSUMER_SPINE_CLIENT_CERT");
+        }
+        if (isInvalidPemFormat(config.getClientKey())) {
+            invalidSslProperties.add("GPC_CONSUMER_SPINE_CLIENT_KEY");
+        }
+        if (isInvalidPemFormat(config.getRootCA())) {
+            invalidSslProperties.add("GPC_CONSUMER_SPINE_ROOT_CA_CERT");
+        }
+        if (isInvalidPemFormat(config.getSubCA())) {
+            invalidSslProperties.add("GPC_CONSUMER_SPINE_SUB_CA_CERT");
+        }
+
+        return invalidSslProperties;
+    }
+
+    private boolean isInvalidPemFormat(String sslProperty) {
+        try {
+            PemFormatter.format(sslProperty);
+            return false;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    private void validateSspUrl(GpcConfiguration config) {
+        var baseUrl = config.getSspUrl();
+
+        if (StringUtils.isBlank(baseUrl)) {
+            config.setSspEnabled(false);
+            return;
+        }
+
+        config.setSspUrl(baseUrl.endsWith("/") ? baseUrl : baseUrl + "/");
+        config.setSspEnabled(true);
+    }
+}

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/validation/GpcConfigurationValidator.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/validation/GpcConfigurationValidator.java
@@ -18,8 +18,8 @@ public class GpcConfigurationValidator implements ConstraintValidator<ValidGpcCo
         "The environment variable(s) %s are not in a valid PEM format";
     private static final String SSL_PROPERTIES_VIOLATION_MESSAGE =
         """
-            You must either use mutual TLS or decide to disable it.
-            To enable mutual TLS you must provide %s environment variable(s).
+            You must either use mutual TLS or decide to disable it.%n\
+            To enable mutual TLS you must provide %s environment variable(s).%n\
             To disable mutual TLS you must remove %s environment variable(s).""";
 
     @Override

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/validation/ValidGpcConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/validation/ValidGpcConfiguration.java
@@ -1,0 +1,20 @@
+package uk.nhs.adaptors.gpc.consumer.gpc.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = GpcConfigurationValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidGpcConfiguration {
+    String message() default "Invalid GPC Configuration";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
This pull request covers validation for the following properties, which are represented in the `GpcConfiguration` class:

- GPC_CONSUMER_SPINE_CLIENT_CERT
- GPC_CONSUMER_SPINE_CLIENT_KEY
- GPC_CONSUMER_SPINE_ROOT_CA_CERT
- GPC_CONSUMER_SPINE_SUB_CA_CERT
- GPC_CONSUMER_SSP_URL

For the `GPC_CONSUMER_SPINE.*` values, the application should error when:

* Some but not all of of the values are set.
* Any of the values are not in a valid PEM format

It should not error when:

* None of the values are set (SSL is not being used).
* All of the values are set (SSL is being used).

In addition it also exposes a method `isSslEnabled` to indicate this.

For the `GPC_CONSUMER_SSP_URL` value, this is valid being empty (SSP is not being used) or populated (SSP is being used).  The SSP URL, if present, is prefixed with a '/' is it does not already end with one.

In addition it also exposed a method `isSspEnabled` to indicated this.


This is the initial pull request to add the validation functionality.  An additional pull request will be created to refactor parts of the application which use this function, to both make use of the new boolean methods, remove any unnecessary duplicated validation which may be taking place and is no longer required and to ensure the gpc configuration is correctly injected into the right places.
