### PR TITLE
Refactor usages of `GpcConfiguration` now the validator is configured.

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SslContextBuilderWrapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SslContextBuilderWrapper.java
@@ -1,52 +1,31 @@
 package uk.nhs.adaptors.gpc.consumer.filters;
 
 import java.security.KeyStore;
-import java.util.ArrayList;
 import java.util.UUID;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 
-import org.apache.commons.lang3.StringUtils;
+import lombok.RequiredArgsConstructor;
 
 import com.heroku.sdk.EnvKeyStore;
 
 import io.netty.handler.ssl.SslContext;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import uk.nhs.adaptors.gpc.consumer.gpc.exception.GpConnectException;
-import uk.nhs.adaptors.gpc.consumer.utils.PemFormatter;
+import org.springframework.stereotype.Component;
+import uk.nhs.adaptors.gpc.consumer.gpc.GpcConfiguration;
 
+@Component
 @Slf4j
+@RequiredArgsConstructor
 public class SslContextBuilderWrapper {
-    private String clientKey;
-    private String clientCert;
-    private String rootCert;
-    private String subCert;
 
-    public SslContextBuilderWrapper clientKey(String clientKey) {
-        this.clientKey = toPem(clientKey);
-        return this;
-    }
-
-    public SslContextBuilderWrapper clientCert(String clientCert) {
-        this.clientCert = toPem(clientCert);
-        return this;
-    }
-
-    public SslContextBuilderWrapper rootCert(String rootCert) {
-        this.rootCert = toPem(rootCert);
-        return this;
-    }
-
-    public SslContextBuilderWrapper subCert(String subCert) {
-        this.subCert = toPem(subCert);
-        return this;
-    }
+    private final GpcConfiguration gpcConfiguration;
 
     @SneakyThrows
     public SslContext buildSSLContext() {
-        if (shouldBuildSslContext()) {
+        if (gpcConfiguration.isSslEnabled()) {
             LOGGER.info("Using SSL context with client certificates for TLS mutual authentication.");
             return buildSSLContextWithClientCertificates();
         }
@@ -59,43 +38,14 @@ public class SslContextBuilderWrapper {
         return io.netty.handler.ssl.SslContextBuilder.forClient().build();
     }
 
-    private boolean shouldBuildSslContext() {
-        final int allSslProperties = 4;
-
-        var missingSslProperties = new ArrayList<String>();
-        if (StringUtils.isBlank(clientKey)) {
-            missingSslProperties.add("GPC_CONSUMER_SPINE_CLIENT_KEY");
-        }
-        if (StringUtils.isBlank(clientCert)) {
-            missingSslProperties.add("GPC_CONSUMER_SPINE_CLIENT_CERT");
-        }
-        if (StringUtils.isBlank(rootCert)) {
-            missingSslProperties.add("GPC_CONSUMER_SPINE_ROOT_CA_CERT");
-        }
-        if (StringUtils.isBlank(subCert)) {
-            missingSslProperties.add("GPC_CONSUMER_SPINE_SUB_CA_CERT");
-        }
-
-        if (missingSslProperties.size() == allSslProperties) {
-            LOGGER.debug("No TLS MA properties were provided. Not configuring an SSL context.");
-            return false;
-        } else if (missingSslProperties.isEmpty()) {
-            LOGGER.debug("All TLS MA properties were provided. Configuration an SSL context.");
-            return true;
-        } else {
-            throw new GpConnectException("All or none of the GPC_CONSUMER_SPINE_ variables must be defined. Missing variables: "
-                + String.join(",", missingSslProperties));
-        }
-    }
-
     @SneakyThrows
     private SslContext buildSSLContextWithClientCertificates() {
-        var caCertChain = subCert + rootCert;
+        var caCertChain = gpcConfiguration.getSubCA() + gpcConfiguration.getRootCA();
 
         var randomPassword = UUID.randomUUID().toString();
 
         KeyStore ks = EnvKeyStore.createFromPEMStrings(
-            clientKey, clientCert,
+            gpcConfiguration.getClientKey(), gpcConfiguration.getClientCert(),
             randomPassword).keyStore();
 
         KeyStore ts = EnvKeyStore.createFromPEMStrings(caCertChain, randomPassword).keyStore();
@@ -113,9 +63,5 @@ public class SslContextBuilderWrapper {
             .keyManager(keyManagerFactory)
             .trustManager(trustManagerFactory)
             .build();
-    }
-
-    private String toPem(String cert) {
-        return StringUtils.isNotBlank(cert) ? PemFormatter.format(cert) : StringUtils.EMPTY;
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SspFilter.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SspFilter.java
@@ -2,7 +2,6 @@ package uk.nhs.adaptors.gpc.consumer.filters;
 
 import java.net.URI;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
@@ -27,28 +26,16 @@ public class SspFilter implements GlobalFilter, Ordered {
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-        if (isSspEnabled()) {
+        if (gpcConfiguration.isSspEnabled()) {
             URI uri = (URI) exchange.getAttributes()
                 .get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR);
 
-            URI resolvedUri = uri.resolve(getSspUrlPrefix() + uri);
+            URI resolvedUri = uri.resolve(gpcConfiguration.getSspUrl() + uri);
 
             exchange.getAttributes()
                 .put(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR, resolvedUri);
         }
         return chain.filter(exchange);
-    }
-
-    private String getSspUrlPrefix() {
-        var baseUrl = gpcConfiguration.getSspUrl();
-        if (!baseUrl.endsWith("/")) {
-            return baseUrl + "/";
-        }
-        return baseUrl;
-    }
-
-    private boolean isSspEnabled() {
-        return StringUtils.isNotBlank(gpcConfiguration.getSspUrl());
     }
 
     @Override

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/validation/GpcConfigurationValidator.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/gpc/validation/GpcConfigurationValidator.java
@@ -74,28 +74,33 @@ public class GpcConfigurationValidator implements ConstraintValidator<ValidGpcCo
     private List<String> checkSslPropertiesAreValidPemFormat(GpcConfiguration config) {
         var invalidSslProperties = new ArrayList<String>();
 
-        if (isInvalidPemFormat(config.getClientCert())) {
+        config.setClientCert(tryGetPemFormatedProperty(config.getClientCert()));
+        config.setClientKey(tryGetPemFormatedProperty(config.getClientKey()));
+        config.setRootCA(tryGetPemFormatedProperty(config.getRootCA()));
+        config.setSubCA(tryGetPemFormatedProperty(config.getSubCA()));
+
+        if (config.getClientCert().isEmpty()) {
             invalidSslProperties.add("GPC_CONSUMER_SPINE_CLIENT_CERT");
         }
-        if (isInvalidPemFormat(config.getClientKey())) {
+        if (config.getClientKey().isEmpty()) {
             invalidSslProperties.add("GPC_CONSUMER_SPINE_CLIENT_KEY");
         }
-        if (isInvalidPemFormat(config.getRootCA())) {
+        if (config.getRootCA().isEmpty()) {
             invalidSslProperties.add("GPC_CONSUMER_SPINE_ROOT_CA_CERT");
         }
-        if (isInvalidPemFormat(config.getSubCA())) {
+        if (config.getSubCA().isEmpty()) {
             invalidSslProperties.add("GPC_CONSUMER_SPINE_SUB_CA_CERT");
         }
 
         return invalidSslProperties;
     }
 
-    private boolean isInvalidPemFormat(String sslProperty) {
+    private String tryGetPemFormatedProperty(String sslProperty) {
         try {
-            PemFormatter.format(sslProperty);
-            return false;
+            return PemFormatter.format(sslProperty);
+
         } catch (Exception e) {
-            return true;
+            return "";
         }
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/web/RequestBuilderService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/web/RequestBuilderService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.gpc.consumer.filters.SslContextBuilderWrapper;
-import uk.nhs.adaptors.gpc.consumer.gpc.GpcConfiguration;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -18,12 +17,11 @@ public class RequestBuilderService {
 
     private static final int BYTE_COUNT = 150 * 1024 * 1024;
 
-    private final GpcConfiguration gpcConfiguration;
+    private final SslContextBuilderWrapper sslContextBuilderWrapper;
 
     @SneakyThrows
     public SslContext buildStandardSslContext() {
-        return new SslContextBuilderWrapper()
-            .buildStandardSslContext();
+        return sslContextBuilderWrapper.buildStandardSslContext();
     }
 
     public ExchangeStrategies buildExchangeStrategies() {


### PR DESCRIPTION
**Note this PR is based from branch `gpc-configuration-validation` and requires that to be merged before this is**

* Update validator to store the PEM formatted strings from the configuration. They are only used in one place, and that is also formatting the values into PEM string.  It makes sense to reduce the duplication and store the formatted value when validating.
* Inject the GpcConfiguration into the SSL builder wrapper rather than passing in from outside method, as this class is the only one that needs to know about the configuration.
* Remove the superfluous validation from SslContextBuilderWrapper.
* Remove the pem formatting steps from SslContextBuilderWrapper as the configuration now stores the formatted values.
* Inject the SslContextBuilderWrapper into RequestBuilderService and remove no longer required GpcConfiguration as it is not relevant to this class.
* Remove the appending of the SspUrlPrefix and the isSspEnabled checks as these are now completed in the validator.
* Remove the value injection of GpcConfiguration fields in TlsMutualAuthRoutingFilter and replace with an injected SslContextBuilderWrapper, meaning these are no longer required.