### PR TITLE
NIAD-3171 - GP Consumer Adaptor should error if any of the required SDS environment variables are missing

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsConfigurationValidationTest.java
@@ -13,19 +13,20 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class SdsConfigurationValidationTest {
 
-
     private static final String URL = "url";
     private static final String API_KEY = "apiKey";
+    private static final String SUPPLIER_ODS_CODE = "supplierOdsCode";
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withUserConfiguration(TestSdsConfiguration.class);
 
     @Test
-    void When_SdsHasUrlAndApiKeyPopulated_Expect_ContextIsCreatedAndValuesAreSet() {
+    void When_SdsConfigurationHasAllValuesPopulated_Expect_ContextIsCreatedAndValuesAreSet() {
         contextRunner
             .withPropertyValues(
                 buildPropertyValue(URL, "https://example.com"),
-                buildPropertyValue(API_KEY, "api-key")
+                buildPropertyValue(API_KEY, "api-key"),
+                buildPropertyValue(SUPPLIER_ODS_CODE, "A00001")
             )
             .run(context -> {
                 assertThat(context)
@@ -46,7 +47,8 @@ public class SdsConfigurationValidationTest {
         contextRunner
             .withPropertyValues(
                 buildPropertyValue(URL, ""),
-                buildPropertyValue(API_KEY, "api-key")
+                buildPropertyValue(API_KEY, "api-key"),
+                buildPropertyValue(SUPPLIER_ODS_CODE, "A00001")
             )
             .run(context -> {
                 assertThat(context).hasFailed();
@@ -64,7 +66,8 @@ public class SdsConfigurationValidationTest {
         contextRunner
             .withPropertyValues(
                 buildPropertyValue(URL, "https://example.com"),
-                buildPropertyValue(API_KEY, "")
+                buildPropertyValue(API_KEY, ""),
+                buildPropertyValue(SUPPLIER_ODS_CODE, "A00001")
             )
             .run(context -> {
                 assertThat(context).hasFailed();
@@ -74,6 +77,24 @@ public class SdsConfigurationValidationTest {
                 assertThat(startupFailure)
                     .rootCause()
                     .hasMessageContaining("The environment variable(s) GPC_CONSUMER_SDS_APIKEY must be provided.");
+            });
+    }
+
+    @Test
+    void When_SdsDoesNotHaveOdsCodePopulated_Expect_ContextIsNotCreated() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue(URL, "https://example.com"),
+                buildPropertyValue(API_KEY, "test-api-key")
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+
+                var startupFailure = context.getStartupFailure();
+
+                assertThat(startupFailure)
+                    .rootCause()
+                    .hasMessageContaining("The environment variable(s) GPC_SUPPLIER_ODS_CODE must be provided.");
             });
     }
 

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/sds/SdsConfigurationValidationTest.java
@@ -1,0 +1,91 @@
+package uk.nhs.adaptors.gpc.consumer.sds;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import uk.nhs.adaptors.gpc.consumer.sds.configuration.SdsConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class SdsConfigurationValidationTest {
+
+
+    private static final String URL = "url";
+    private static final String API_KEY = "apiKey";
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(TestSdsConfiguration.class);
+
+    @Test
+    void When_SdsHasUrlAndApiKeyPopulated_Expect_ContextIsCreatedAndValuesAreSet() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue(URL, "https://example.com"),
+                buildPropertyValue(API_KEY, "api-key")
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(SdsConfiguration.class);
+
+                var sdsConfiguration = context.getBean(SdsConfiguration.class);
+
+                assertAll(
+                    () -> assertThat(sdsConfiguration.getUrl()).isNotEmpty(),
+                    () -> assertThat(sdsConfiguration.getApiKey()).isNotEmpty()
+                );
+            });
+    }
+
+    @Test
+    void When_SdsDoesNotHaveUrlPopulated_Expect_ContextIsNotCreated() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue(URL, ""),
+                buildPropertyValue(API_KEY, "api-key")
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+
+                var startupFailure = context.getStartupFailure();
+
+                assertThat(startupFailure)
+                    .rootCause()
+                    .hasMessageContaining("The environment variable(s) GPC_CONSUMER_SDS_URL must be provided.");
+            });
+    }
+
+    @Test
+    void When_SdsDoesNotHaveApiKeyPopulated_Expect_ContextIsNotCreated() {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue(URL, "https://example.com"),
+                buildPropertyValue(API_KEY, "")
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+
+                var startupFailure = context.getStartupFailure();
+
+                assertThat(startupFailure)
+                    .rootCause()
+                    .hasMessageContaining("The environment variable(s) GPC_CONSUMER_SDS_APIKEY must be provided.");
+            });
+    }
+
+    @Contract(pure = true)
+    private static @NotNull String buildPropertyValue(String propertyName, String value) {
+        return String.format("gpc-consumer.sds.%s=%s", propertyName, value);
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(SdsConfiguration.class)
+    static class TestSdsConfiguration {
+    }
+}
+
+

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/configuration/SdsConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/configuration/SdsConfiguration.java
@@ -15,4 +15,5 @@ import uk.nhs.adaptors.gpc.consumer.sds.validation.ValidSdsConfiguration;
 public class SdsConfiguration {
     private String url;
     private String apiKey;
+    private String supplierOdsCode;
 }

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/configuration/SdsConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/configuration/SdsConfiguration.java
@@ -1,15 +1,17 @@
 package uk.nhs.adaptors.gpc.consumer.sds.configuration;
 
+import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+import uk.nhs.adaptors.gpc.consumer.sds.validation.ValidSdsConfiguration;
 
 @Component
 @ConfigurationProperties(prefix = "gpc-consumer.sds")
-@Getter
-@Setter
+@Data
+@Validated
+@ValidSdsConfiguration
 public class SdsConfiguration {
     private String url;
     private String apiKey;

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/validation/SdsConfigurationValidator.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/validation/SdsConfigurationValidator.java
@@ -27,6 +27,10 @@ public class SdsConfigurationValidator implements ConstraintValidator<ValidSdsCo
             missingSdsProperties.add("GPC_CONSUMER_SDS_APIKEY");
         }
 
+        if (StringUtils.isEmpty(config.getSupplierOdsCode())) {
+            missingSdsProperties.add("GPC_SUPPLIER_ODS_CODE");
+        }
+
         if (missingSdsProperties.isEmpty()) {
             return true;
         }

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/validation/SdsConfigurationValidator.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/validation/SdsConfigurationValidator.java
@@ -1,0 +1,45 @@
+package uk.nhs.adaptors.gpc.consumer.sds.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import uk.nhs.adaptors.gpc.consumer.sds.configuration.SdsConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class SdsConfigurationValidator implements ConstraintValidator<ValidSdsConfiguration, SdsConfiguration> {
+
+    private static final String SDS_CONFIGURATION_VIOLATION_MESSAGE =
+        "The environment variable(s) %s must be provided.";
+
+    @Override
+    public boolean isValid(SdsConfiguration config, ConstraintValidatorContext context) {
+        List<String> missingSdsProperties = new ArrayList<>();
+
+        if (StringUtils.isEmpty(config.getUrl())) {
+            missingSdsProperties.add("GPC_CONSUMER_SDS_URL");
+        }
+
+        if (StringUtils.isEmpty(config.getApiKey())) {
+            missingSdsProperties.add("GPC_CONSUMER_SDS_APIKEY");
+        }
+
+        if (missingSdsProperties.isEmpty()) {
+            return true;
+        }
+
+        var message = String.format(SDS_CONFIGURATION_VIOLATION_MESSAGE, String.join(", ", missingSdsProperties));
+        setConstraintViolation(context, message);
+        return false;
+
+    }
+
+    private static void setConstraintViolation(ConstraintValidatorContext context, String message) {
+        LOGGER.error(message);
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+    }
+}

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/validation/ValidSdsConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/validation/ValidSdsConfiguration.java
@@ -1,0 +1,20 @@
+package uk.nhs.adaptors.gpc.consumer.sds.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = SdsConfigurationValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidSdsConfiguration {
+    String message() default "Invalid SDS Configuration";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
This pull request covers validation for the following properties, which are represented in the `SdsConfiguration` class:

* GPC_CONSUMER_SDS_URL
* GPC_CONSUMER_SDS_APIKEY
* GPC_SUPPLIER_ODS_CODE

For `GPC_CONSUMER_SDS_URL`, `GPC_CONSUMER_APIKEY` and `GPC_SUPPLIER_ODSCODE` environment variables, the application should fail to start if any of the above values are missing or empty and should display a suitable error  message.

This will make it easier for users of the adaptor to identify required environment variables which are missing, by preventing the adaptor from starting when they are missing.