### PR TITLE
Remove dependency on `junit-jupiter-params`

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -40,7 +40,6 @@ dependencies {
 	// Test
 	testImplementation "org.springframework.boot:spring-boot-starter-test"
 	testImplementation "com.jayway.jsonpath:json-path:2.9.0"
-	testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.3"
 	testImplementation "com.github.tomakehurst:wiremock-standalone:3.0.1"
 	testImplementation "org.assertj:assertj-core:3.27.3"
 	testImplementation "org.testcontainers:testcontainers:1.20.4"


### PR DESCRIPTION
Already exists as a dependency from `spring-boot-starter-test`. 

By managing this dependency separately we are creating a versioning conflict.

Removing the explicit dependency on `junit-jupiter-params` allows spring boot to manage the versions for us.