### PR TITLE
Make use of validated GPC Configuration

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduced configuration validation on `GPC_CONSUMER` environment variables at application startup.
+
+  To use TLS Mutual Authentication, then *all* the following environment variables must be provided and in a valid PEM 
+  format: `GPC_CONSUMER_SPINE_CLIENT_CERT`, `GPC_CONSUMER_SPINE_CLIENT_KEY`, `GPC_CONSUMER_SPINE_ROOT_CA_CERT`, 
+  `GPC_CONSUMER_SPINE_SUB_CA_CERT`. 
+
+  To disable TLS Mutual Authentication, then *none* of the above-listed environment variables should be provided.
+
+  In the event that only some of the environment variables are provided, the application will fail to start and an error
+  will be presented detailing which environment variables to add or remove.  If any of the above-listed environment
+  variables are provided but are not in a valid PEM format, then the application will report the affected environment 
+  variables and fail to start.
+
 ## [1.0.1] - 2024-06-06
 
 ### Fixed

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
@@ -1,15 +1,21 @@
 package uk.nhs.adaptors.gpc.consumer.gpc;
 
+import io.netty.handler.ssl.SslContext;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Configuration;
+import uk.nhs.adaptors.gpc.consumer.filters.SslContextBuilderWrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@ExtendWith(OutputCaptureExtension.class)
 public class GpcConfigurationValidationTest {
 
     private static final String VALID_CERTIFICATE =
@@ -71,7 +77,7 @@ public class GpcConfigurationValidationTest {
     private static final String SUB_CA = "subCA";
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-        .withUserConfiguration(TestGpcConfiguration.class);
+        .withUserConfiguration(TestGpcConfiguration.class, SslContextBuilderWrapper.class);
 
     @Test
     void When_GpcConfigurationContainsAllSslProperties_Expect_IsContextIsCreatedAndShouldUseSslIsTrue() {
@@ -232,7 +238,7 @@ public class GpcConfigurationValidationTest {
     void When_GpcConfigurationDoesNotHaveSspUrlPresent_Expect_ContextIsCreatedAndIsNotSspEnabled() {
         contextRunner
             .withPropertyValues(
-                buildPropertyValue("sspUrl", "")
+                buildPropertyValue("sspUrl", "/this-is-a-url.com")
             )
             .run(context -> {
                 assertThat(context)
@@ -243,6 +249,78 @@ public class GpcConfigurationValidationTest {
                 assertThat(gpcConfiguration.isSspEnabled()).isFalse();
             });
     }
+
+    @Test
+    void When_SslEnabled_Expect_ConfigurationInjectedCorrectlyIntoSslBuilderWrapperAndSslContextUsesTLS(CapturedOutput capturedOutput) {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue(CLIENT_CERT, VALID_CERTIFICATE),
+                buildPropertyValue(CLIENT_KEY, VALID_RSA_PRIVATE_KEY),
+                buildPropertyValue(ROOT_CA, VALID_CERTIFICATE),
+                buildPropertyValue(SUB_CA, VALID_CERTIFICATE)
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(SslContextBuilderWrapper.class);
+
+                SslContextBuilderWrapper wrapper = context.getBean(SslContextBuilderWrapper.class);
+
+                SslContext sslContext = wrapper.buildSSLContext();
+                assertThat(sslContext).isNotNull();
+
+                assertThat(capturedOutput.getOut()).contains("Using standard SSL context. TLS mutual authentication is not enabled.");
+            });
+    }
+
+    @Test
+    void When_SslDisabled_Expect_ConfigurationInjectedIntoSslBuilderWrapperAndSslContextDoesNotUseTLS(
+        CapturedOutput capturedOutput
+    ) {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue(CLIENT_CERT, ""),
+                buildPropertyValue(CLIENT_KEY, ""),
+                buildPropertyValue(ROOT_CA, ""),
+                buildPropertyValue(SUB_CA, "")
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(SslContextBuilderWrapper.class);
+
+                SslContextBuilderWrapper wrapper = context.getBean(SslContextBuilderWrapper.class);
+
+                var sslContext = wrapper.buildSSLContext();
+                assertThat(sslContext).isNotNull();
+
+                assertThat(capturedOutput.getOut()).contains("Using standard SSL context. TLS mutual authentication is not enabled.");
+            });
+    }
+
+    @Test
+    void When_SslEnabled_Expect_ConfigurationInjectedIntoSslBuilderWrapperAndSslContextDoesNotUseTLS(CapturedOutput capturedOutput) {
+        contextRunner
+            .withPropertyValues(
+                buildPropertyValue(CLIENT_CERT, VALID_CERTIFICATE),
+                buildPropertyValue(CLIENT_KEY, VALID_RSA_PRIVATE_KEY),
+                buildPropertyValue(ROOT_CA, VALID_CERTIFICATE),
+                buildPropertyValue(SUB_CA, VALID_CERTIFICATE)
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(SslContextBuilderWrapper.class);
+
+                SslContextBuilderWrapper wrapper = context.getBean(SslContextBuilderWrapper.class);
+
+                var sslContext = wrapper.buildSSLContext();
+                assertThat(sslContext).isNotNull();
+
+                assertThat(capturedOutput.getOut()).contains("Using SSL context with client certificates for TLS mutual authentication.");
+            });
+    }
+
 
     @Contract(pure = true)
     private static @NotNull String buildPropertyValue(String propertyName, String value) {

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/gpc/GpcConfigurationValidationTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
-import uk.nhs.adaptors.gpc.consumer.filters.SslContextBuilderWrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -72,7 +71,7 @@ public class GpcConfigurationValidationTest {
     private static final String SUB_CA = "subCA";
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-        .withUserConfiguration(TestGpcConfiguration.class, SslContextBuilderWrapper.class);
+        .withUserConfiguration(TestGpcConfiguration.class);
 
     @Test
     void When_GpcConfigurationContainsAllSslProperties_Expect_IsContextIsCreatedAndShouldUseSslIsTrue() {

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SslContextBuilderWrapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SslContextBuilderWrapper.java
@@ -1,52 +1,36 @@
 package uk.nhs.adaptors.gpc.consumer.filters;
 
 import java.security.KeyStore;
-import java.util.ArrayList;
 import java.util.UUID;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
-
-import org.apache.commons.lang3.StringUtils;
 
 import com.heroku.sdk.EnvKeyStore;
 
 import io.netty.handler.ssl.SslContext;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import uk.nhs.adaptors.gpc.consumer.gpc.exception.GpConnectException;
+import org.springframework.beans.factory.annotation.Value;
 import uk.nhs.adaptors.gpc.consumer.utils.PemFormatter;
+
 
 @Slf4j
 public class SslContextBuilderWrapper {
+    @Value("${gpc-consumer.gpc.clientKey}")
     private String clientKey;
+    @Value("${gpc-consumer.gpc.clientCert}")
     private String clientCert;
-    private String rootCert;
-    private String subCert;
-
-    public SslContextBuilderWrapper clientKey(String clientKey) {
-        this.clientKey = toPem(clientKey);
-        return this;
-    }
-
-    public SslContextBuilderWrapper clientCert(String clientCert) {
-        this.clientCert = toPem(clientCert);
-        return this;
-    }
-
-    public SslContextBuilderWrapper rootCert(String rootCert) {
-        this.rootCert = toPem(rootCert);
-        return this;
-    }
-
-    public SslContextBuilderWrapper subCert(String subCert) {
-        this.subCert = toPem(subCert);
-        return this;
-    }
+    @Value("${gpc-consumer.gpc.rootCA}")
+    private String rootCA;
+    @Value("${gpc-consumer.gpc.subCA}")
+    private String subCA;
+    @Value("${gpc-consumer.gpc.sslEnabled}")
+    private boolean sslEnabled;
 
     @SneakyThrows
     public SslContext buildSSLContext() {
-        if (shouldBuildSslContext()) {
+        if (sslEnabled) {
             LOGGER.info("Using SSL context with client certificates for TLS mutual authentication.");
             return buildSSLContextWithClientCertificates();
         }
@@ -59,44 +43,17 @@ public class SslContextBuilderWrapper {
         return io.netty.handler.ssl.SslContextBuilder.forClient().build();
     }
 
-    private boolean shouldBuildSslContext() {
-        final int allSslProperties = 4;
-
-        var missingSslProperties = new ArrayList<String>();
-        if (StringUtils.isBlank(clientKey)) {
-            missingSslProperties.add("GPC_CONSUMER_SPINE_CLIENT_KEY");
-        }
-        if (StringUtils.isBlank(clientCert)) {
-            missingSslProperties.add("GPC_CONSUMER_SPINE_CLIENT_CERT");
-        }
-        if (StringUtils.isBlank(rootCert)) {
-            missingSslProperties.add("GPC_CONSUMER_SPINE_ROOT_CA_CERT");
-        }
-        if (StringUtils.isBlank(subCert)) {
-            missingSslProperties.add("GPC_CONSUMER_SPINE_SUB_CA_CERT");
-        }
-
-        if (missingSslProperties.size() == allSslProperties) {
-            LOGGER.debug("No TLS MA properties were provided. Not configuring an SSL context.");
-            return false;
-        } else if (missingSslProperties.isEmpty()) {
-            LOGGER.debug("All TLS MA properties were provided. Configuration an SSL context.");
-            return true;
-        } else {
-            throw new GpConnectException("All or none of the GPC_CONSUMER_SPINE_ variables must be defined. Missing variables: "
-                + String.join(",", missingSslProperties));
-        }
-    }
-
     @SneakyThrows
     private SslContext buildSSLContextWithClientCertificates() {
-        var caCertChain = subCert + rootCert;
+        var caCertChain = toPem(subCA) + toPem(rootCA);
 
         var randomPassword = UUID.randomUUID().toString();
 
         KeyStore ks = EnvKeyStore.createFromPEMStrings(
-            clientKey, clientCert,
-            randomPassword).keyStore();
+            toPem(clientKey),
+            toPem(clientCert),
+            randomPassword
+        ).keyStore();
 
         KeyStore ts = EnvKeyStore.createFromPEMStrings(caCertChain, randomPassword).keyStore();
 
@@ -116,6 +73,6 @@ public class SslContextBuilderWrapper {
     }
 
     private String toPem(String cert) {
-        return StringUtils.isNotBlank(cert) ? PemFormatter.format(cert) : StringUtils.EMPTY;
+        return PemFormatter.format(cert);
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SslContextBuilderWrapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SslContextBuilderWrapper.java
@@ -36,8 +36,9 @@ public class SslContextBuilderWrapper {
     }
     @SneakyThrows
     public SslContext buildStandardSslContext() {
-        LOGGER.info("Using standard SSL context.");
-        return io.netty.handler.ssl.SslContextBuilder.forClient().build();
+        var sslContext = io.netty.handler.ssl.SslContextBuilder.forClient().build();
+        LOGGER.info("Built standard SSL context.");
+        return sslContext;
     }
 
     @SneakyThrows
@@ -62,11 +63,14 @@ public class SslContextBuilderWrapper {
             TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init(ts);
 
-        return io.netty.handler.ssl.SslContextBuilder
+        var sslContext =  io.netty.handler.ssl.SslContextBuilder
             .forClient()
             .keyManager(keyManagerFactory)
             .trustManager(trustManagerFactory)
             .build();
+
+        LOGGER.info("Built SSL context for TLS.");
+        return sslContext;
     }
 
     private String toPem(String cert) {

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/TlsMutualAuthRoutingFilter.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/TlsMutualAuthRoutingFilter.java
@@ -16,16 +16,20 @@ import reactor.netty.http.client.HttpClient;
 @Component
 public class TlsMutualAuthRoutingFilter extends NettyRoutingFilter {
 
+    private final SslContextBuilderWrapper sslContextBuilderWrapper;
+
     public TlsMutualAuthRoutingFilter(
         HttpClient httpClient,
         ObjectProvider<List<HttpHeadersFilter>> headersFiltersProvider,
-        HttpClientProperties properties) {
+        HttpClientProperties properties,
+        SslContextBuilderWrapper sslContextBuilderWrapper) {
         super(httpClient, headersFiltersProvider, properties);
+        this.sslContextBuilderWrapper = sslContextBuilderWrapper;
     }
 
     @Override
     protected HttpClient getHttpClient(Route route, ServerWebExchange exchange) {
-        SslContext sslContext = new SslContextBuilderWrapper().buildSSLContext();
+        SslContext sslContext = sslContextBuilderWrapper.buildSSLContext();
         return HttpClient.create().secure(t -> t.sslContext(sslContext));
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/TlsMutualAuthRoutingFilter.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/TlsMutualAuthRoutingFilter.java
@@ -3,7 +3,6 @@ package uk.nhs.adaptors.gpc.consumer.filters;
 import java.util.List;
 
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.config.HttpClientProperties;
 import org.springframework.cloud.gateway.filter.NettyRoutingFilter;
 import org.springframework.cloud.gateway.filter.headers.HttpHeadersFilter;
@@ -16,14 +15,6 @@ import reactor.netty.http.client.HttpClient;
 
 @Component
 public class TlsMutualAuthRoutingFilter extends NettyRoutingFilter {
-    @Value("${gpc-consumer.gpc.clientKey}")
-    private String clientKey;
-    @Value("${gpc-consumer.gpc.clientCert}")
-    private String clientCert;
-    @Value("${gpc-consumer.gpc.rootCA}")
-    private String rootCA;
-    @Value("${gpc-consumer.gpc.subCA}")
-    private String subCA;
 
     public TlsMutualAuthRoutingFilter(
         HttpClient httpClient,
@@ -34,13 +25,7 @@ public class TlsMutualAuthRoutingFilter extends NettyRoutingFilter {
 
     @Override
     protected HttpClient getHttpClient(Route route, ServerWebExchange exchange) {
-        SslContext sslContext = new SslContextBuilderWrapper()
-            .clientKey(clientKey)
-            .clientCert(clientCert)
-            .rootCert(rootCA)
-            .subCert(subCA)
-            .buildSSLContext();
-
+        SslContext sslContext = new SslContextBuilderWrapper().buildSSLContext();
         return HttpClient.create().secure(t -> t.sslContext(sslContext));
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/UrlsInResponseBodyRewriteFunction.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/UrlsInResponseBodyRewriteFunction.java
@@ -5,9 +5,9 @@ import static uk.nhs.adaptors.gpc.consumer.utils.UrlHelpers.getUrlBase;
 import java.net.URI;
 
 import com.google.common.net.HttpHeaders;
-import org.apache.commons.lang3.StringUtils;
+import lombok.RequiredArgsConstructor;
 import org.reactivestreams.Publisher;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.factory.rewrite.RewriteFunction;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.stereotype.Component;
@@ -15,13 +15,15 @@ import org.springframework.web.server.ServerWebExchange;
 
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
+import uk.nhs.adaptors.gpc.consumer.gpc.GpcConfiguration;
 import uk.nhs.adaptors.gpc.consumer.utils.LoggingUtil;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class UrlsInResponseBodyRewriteFunction implements RewriteFunction<String, String> {
-    @Value("${gpc-consumer.gpc.sspUrl}")
-    private String sspUrl;
+
+    private final GpcConfiguration config;
 
     @Override
     public Publisher<String> apply(ServerWebExchange exchange, String responseBody) {
@@ -34,8 +36,8 @@ public class UrlsInResponseBodyRewriteFunction implements RewriteFunction<String
 
                 URI proxyTargetUri = (URI) exchange.getAttributes().get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR);
 
-                if (isSspEnabled()) {
-                    var uriAsStringWithoutSspPrefix = proxyTargetUri.toString().substring(getSspUrlWithTrailingSlash().length());
+                if (config.isSspEnabled()) {
+                    var uriAsStringWithoutSspPrefix = proxyTargetUri.toString().substring(config.getSspUrl().length());
                     proxyTargetUri = proxyTargetUri.resolve(uriAsStringWithoutSspPrefix);
                 }
 
@@ -46,16 +48,5 @@ public class UrlsInResponseBodyRewriteFunction implements RewriteFunction<String
                     gpcProducerUrlPrefix, gpcConsumerUrlPrefix);
                 return originalResponseBody.replaceAll("(?i)" + gpcProducerUrlPrefix, gpcConsumerUrlPrefix);
             });
-    }
-
-    private boolean isSspEnabled() {
-        return StringUtils.isNotBlank(sspUrl);
-    }
-
-    private String getSspUrlWithTrailingSlash() {
-        if (!sspUrl.endsWith("/")) {
-            return sspUrl + "/";
-        }
-        return sspUrl;
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/web/RequestBuilderService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/web/RequestBuilderService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.gpc.consumer.filters.SslContextBuilderWrapper;
-import uk.nhs.adaptors.gpc.consumer.gpc.GpcConfiguration;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -18,12 +17,11 @@ public class RequestBuilderService {
 
     private static final int BYTE_COUNT = 150 * 1024 * 1024;
 
-    private final GpcConfiguration gpcConfiguration;
+    private final SslContextBuilderWrapper sslContextBuilderWrapper;
 
     @SneakyThrows
     public SslContext buildStandardSslContext() {
-        return new SslContextBuilderWrapper()
-            .buildStandardSslContext();
+        return sslContextBuilderWrapper.buildStandardSslContext();
     }
 
     public ExchangeStrategies buildExchangeStrategies() {

--- a/service/src/test/java/uk/nhs/adaptors/gpc/consumer/gpc/SslContextBuilderWrapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gpc/consumer/gpc/SslContextBuilderWrapperTest.java
@@ -1,0 +1,89 @@
+package uk.nhs.adaptors.gpc.consumer.gpc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import uk.nhs.adaptors.gpc.consumer.filters.SslContextBuilderWrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(OutputCaptureExtension.class)
+public class SslContextBuilderWrapperTest {
+
+    private static final String VALID_CERTIFICATE =
+        """
+            -----BEGIN CERTIFICATE-----
+            MIIDhzCCAm+gAwIBAgIESK+5NTANBgkqhkiG9w0BAQsFADBbMScwJQYDVQQDDB5SZWdlcnkgU2Vs
+            Zi1TaWduZWQgQ2VydGlmaWNhdGUxIzAhBgNVBAoMGlJlZ2VyeSwgaHR0cHM6Ly9yZWdlcnkuY29t
+            MQswCQYDVQQGEwJVQTAgFw0yNTAxMjAwMDAwMDBaGA8yMTI1MDEyMDEwMzYyNVowSTEVMBMGA1UE
+            AwwMdGVzdC1zc2wuY29tMSMwIQYDVQQKDBpSZWdlcnksIGh0dHBzOi8vcmVnZXJ5LmNvbTELMAkG
+            A1UEBhMCVUEwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCgTdIL7LEaTBbQiAziGocB
+            gGNXBHHY5f8Rjit4FS+l12VR/Q9CcZU8nTc6V2mqPyxbgS/ATxpaWTPHbNGy/1VRWij1OCOTwFB2
+            dBKKFKfIPya3JCY7RYKbvEH+Nrgc0fwJ3dqQ9Cv5w8oIsuM8HS34Y9mr/KlfpWc9fLxTDTmHCf4a
+            /rYdRxQZfLwg2zi4rHaURn9T/S0jZMT0rwETajgnQl5WPfDV4d3Wslkz6ohEcQnvpDfB6mRSqA+C
+            iFgOBDEnREW6UsEFX/kPP9O64HAQzrMwdlPso3BiVMO/rgZ2VX709vj1Wti1hJARwZeMfg0fXLnE
+            MfRvUqoYm1mxSpc5AgMBAAGjYzBhMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMB0G
+            A1UdDgQWBBQdR0XRwEDaOUdmKm21TXPncLJDhDAfBgNVHSMEGDAWgBQdR0XRwEDaOUdmKm21TXPn
+            cLJDhDANBgkqhkiG9w0BAQsFAAOCAQEAMqf4IhZEBCcJx8TiHLNDc3AMpy49xBVZ7ANgd4cKjcSa
+            L4sBFuT39ARn+SvFP76sNPDCzZC+xDsDLPgd4Jwweyko8hjYk02MR7FpdzlUPbVsPvfwJ1ynAb71
+            VWWmvULKmXvPkOJkqdGnB2k89SXH80wMnl6YErXX3w6N3HOFjYUdyTWZmwCJ/MOBwDyOb3i8fcY+
+            td+K1KtqWBrntnTic+4y2inBgI+Wipf3a+EbwbzkgU01EgTaCykhkoh7fZfNwQ5VGY+AcyNbd0xX
+            WjDDOYAag96BLBMAgvjZqFl67tL+/CNO9o4YEPZ7pg0FvI3/Xp9L3edXvvzLREbaHxCnjQ==
+            -----END CERTIFICATE-----""";
+
+    private static final String VALID_RSA_PRIVATE_KEY =
+        """
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEowIBAAKCAQEAoE3SC+yxGkwW0IgM4hqHAYBjVwRx2OX/EY4reBUvpddlUf0P
+            QnGVPJ03Oldpqj8sW4EvwE8aWlkzx2zRsv9VUVoo9Tgjk8BQdnQSihSnyD8mtyQm
+            O0WCm7xB/ja4HNH8Cd3akPQr+cPKCLLjPB0t+GPZq/ypX6VnPXy8Uw05hwn+Gv62
+            HUcUGXy8INs4uKx2lEZ/U/0tI2TE9K8BE2o4J0JeVj3w1eHd1rJZM+qIRHEJ76Q3
+            wepkUqgPgohYDgQxJ0RFulLBBV/5Dz/TuuBwEM6zMHZT7KNwYlTDv64GdlV+9Pb4
+            9VrYtYSQEcGXjH4NH1y5xDH0b1KqGJtZsUqXOQIDAQABAoIBAAVVEVucL/fz9/5P
+            yD3tK/h80NEgMLlKTUXEOOXxrngRxikIBe3r4U7229Nw/O7Q0yToEzKObw36UaKc
+            mA0gOTJPkXU2vNg5WXPXQJafQUWD9EG7ThpCoamUhY1zPISY541cd9zCgoP4Y0wO
+            x0hEoDbW+3KhIPExi1GcSJdqpTM8sEmzDnFIXylAEYhOVgjvZLt0LhleTzF5qlmG
+            ywfyFJhAhkPXe6AhONKFAsBNFxEse4fljcCijbtzauBrw7K6amd+Rp8j+bwsrAqW
+            a5FLerEnVGKQAugg4oj8q1N6iuTqGWVtO/SSykLgGSEWlW15+X0qJcLDz/XCFR0+
+            ZHN+ypECgYEA44rEcHAWc1MgO3KaVg5ST8TLzwwWTK+Nf0nZ4qhVksZqcxBgTNot
+            y2lF9u03wGwKzn0nqSBJqMYNFNjrGQZ9MDjyflCN3oTKgsVgIKssx26rGojfO5Qh
+            54RBfory/YR3zhGETeF0eW/hbneRLPpEPeGAaJCbaPLLDFJaazHxnUMCgYEAtFpJ
+            SWT92HtLvEqv727/xMX6RXi0jN3l2qo6g46mMn3Vvpsmgq2hK9KrLYNPvi9Z78bo
+            3rKAg2qmcu5aiAOFdiNRh9WAM78+iaJc3OZ6WpWwVUMFxxEh3iM330IiGIJsr4jz
+            ridOUXRVKAoEb7spfZxRZ6QjJG6q+mOrXDD+E9MCgYAHfTC79qR2hTzhWANGY9BH
+            udVvahltyrVghCC8ugee/hLQ2LAit2ecc0mPN/2GwseURkBA68Qg3uvdTMpoF3OV
+            W7p3d9VDhqFXroFcceXWZokRJYIbZuO6x/qT3KTkvTBoQuFU4t+/g3Qq+5p2nYIT
+            e1GLn37N9HfEXw2Ey68FGwKBgQCZF5bkPV0ZeTfFwqRrm45zKxcSB69DcEzf++Yl
+            rF45uAVLggoDnX2VZIO346I6L5mpZvBfsahTZaGbJ+cjU9HjgYGAy2PDCVD9phwr
+            y10LLct75KOv4kQce0q/MjUdFwFJU/h92ZGqpRRwI2i2q2pB3QJg9rx5/ZMXbqmU
+            XWYfzwKBgGyCA1NLMoPKPdaKnYHkoAwi7/ytLsA7IpLCg+NkiA6B7THGh60IpH7B
+            RLwFShJRFGA+z4b1WoGPcmUloSJsMI6EjZDuG1gcWAbENWrcqkMKKJH6f9X/5pIq
+            frOEfuS/2Ie8Rj8PZhhFoekjQHgtzba4w4oqfo1YeBFYc6QH/QKb
+            -----END RSA PRIVATE KEY-----""";
+
+
+    @Test
+    void When_BuildSslContextAndTlsIsEnabled_Expect_TLSEnabledSSLContextIsBuilt(CapturedOutput capturedOutput) {
+        var gpcConfiguration = new GpcConfiguration();
+        gpcConfiguration.setClientCert(VALID_CERTIFICATE);
+        gpcConfiguration.setClientKey(VALID_RSA_PRIVATE_KEY);
+        gpcConfiguration.setRootCA(VALID_CERTIFICATE);
+        gpcConfiguration.setSubCA(VALID_CERTIFICATE);
+        gpcConfiguration.setSslEnabled(true);
+
+        new SslContextBuilderWrapper(gpcConfiguration).buildSSLContext();
+
+        assertThat(capturedOutput.getOut()).contains("Built SSL context for TLS.");
+    }
+
+    @Test
+    void When_BuildSslContextAndTlsIsNotEnabled_Expect_StandardSSLContextIsBuilt(CapturedOutput capturedOutput) {
+        var gpcConfiguration = new GpcConfiguration();
+        gpcConfiguration.setSslEnabled(false);
+
+        new SslContextBuilderWrapper(gpcConfiguration).buildSSLContext();
+
+        assertThat(capturedOutput.getOut()).contains("Built standard SSL context.");
+    }
+}


### PR DESCRIPTION
Following the changes which introduce [startup validation on the GpcConfiguration class](https://github.com/NHSDigital/integration-adaptor-gpc-consumer/pull/206), we can now make use of this directly and use the helper methods to query the state of configuration.

* Inject `GpcConfiguration` directly into `UrlsInResponseBodyRewriteFunction` and use directly.
* Remove @value usages of the configuration in `TlsMutualAuthorityRoutingFilter` as they were not used in the class and simply passed to the `SslContextBuilderWrapper`.
* Inject `GpcConfiguration` directly into `SslContextBuilderWrapper` as this is the class that requires the usage of it