### PR TITLE
NIAD-3281: JVM heap memory allocation set to 50% in any container

### DIFF
--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=package /home/gradle/service/build/libs/gpc-consumer.jar /app/gpc-co
 
 USER 65534
 
-ENTRYPOINT ["java","-Dreactor.netty.http.server.accessLogEnabled=true", "-jar", "/app/gpc-consumer.jar"]
+ENTRYPOINT ["java", "-Dreactor.netty.http.server.accessLogEnabled=true", "-XX:MaxRAMPercentage=50.0", "-jar", "/app/gpc-consumer.jar"]


### PR DESCRIPTION
By default, the JVM allocates only 25% of a container's memory to the heap. In our memory-intensive environment, this has led to OOM issues. This PR increases the max heap allocation to 50% to mitigate these problems.