### PR TITLE
Adjusting the scope for integration tests

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/CloudGatewayRouteBaseTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/CloudGatewayRouteBaseTest.java
@@ -11,7 +11,7 @@ import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import lombok.Getter;
 import uk.nhs.adaptors.gpc.consumer.testcontainers.GpccMockExtension;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = ConsumerApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(GpccMockExtension.class)
 public class CloudGatewayRouteBaseTest {
 

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/HealthCheckTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/HealthCheckTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(classes = ConsumerApplication.class, webEnvironment = RANDOM_PORT)
 @DirtiesContext
 public class HealthCheckTest {
     private static final String HEALTHCHECK_ENDPOINT = "/healthcheck";


### PR DESCRIPTION
## What

Adjusting the scope for integration tests and making the list of depended resources more narrow for faster test runs

## Why

Some integration tests do not need the whole Spring Boot context in order to run tests hence removing and narrowing the list of  resources that tests depending on should make the tests to run faster

## Type of Change

Please check the option(s) that apply.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Internal change (non-breaking change with no effect on functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](../CHANGELOG.MD) with details of my change in the UNRELEASED section, if this change will affect end users
